### PR TITLE
fix(framerate): a frame stall must not collapse the zoom-rate estimate (Dasher-Android #35)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ if(BUILD_CAPI)
         endfunction()
 
         dasher_add_test(dasher_capi_tests test_capi.cpp)
+        dasher_add_test(dasher_framerate_tests test_framerate.cpp)
         dasher_add_test(dasher_interaction_tests test_interaction.cpp)
         dasher_add_test(dasher_direct_mode_shadow_tests test_direct_mode_shadow.cpp)
         dasher_add_test(dasher_low_memory_tests test_low_memory.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ if(BUILD_CAPI)
         endfunction()
 
         dasher_add_test(dasher_capi_tests test_capi.cpp)
-        dasher_add_test(dasher_framerate_tests test_framerate.cpp)
+        dasher_add_test_internal(dasher_framerate_tests test_framerate.cpp)
         dasher_add_test(dasher_interaction_tests test_interaction.cpp)
         dasher_add_test(dasher_direct_mode_shadow_tests test_direct_mode_shadow.cpp)
         dasher_add_test(dasher_low_memory_tests test_low_memory.cpp)

--- a/src/DasherCore/FrameRate.cpp
+++ b/src/DasherCore/FrameRate.cpp
@@ -34,10 +34,20 @@ void CFrameRate::RecordFrame(unsigned long Time) {
     // pre-stall estimate. 250ms ≈ 15 dropped frames at 60fps — generous
     // enough never to trigger on scheduler jitter.
     if (m_iLastFrameTime != 0 && Time > m_iLastFrameTime && Time - m_iLastFrameTime > 250) {
-        m_iTime = Time;
-        m_iFrames = 0;
-        m_iLastFrameTime = Time;
-        return;
+        if (m_iSuspensions < kMaxConsecutiveSuspensions) {
+            m_iSuspensions++;
+            m_iTime = Time;
+            m_iFrames = 0;
+            m_iLastFrameTime = Time;
+            return;
+        }
+        // Third-and-later long gaps in a row: this is not an interrupted
+        // cadence, it IS the cadence (a frontend genuinely rendering below
+        // ~4fps). Let the frame record normally so LP_FRAMERATE adapts to
+        // reality — otherwise Steps() stays tuned for a framerate the
+        // frontend no longer achieves and text entry stalls.
+    } else {
+        m_iSuspensions = 0; // a normal-gap frame re-arms the guard
     }
     m_iLastFrameTime = Time;
 

--- a/src/DasherCore/FrameRate.cpp
+++ b/src/DasherCore/FrameRate.cpp
@@ -43,9 +43,10 @@ void CFrameRate::RecordFrame(unsigned long Time) {
     // cadence, however bursty. (Monotonicity is assumed; on platforms
     // where unsigned long wraps (~49.7 days of ms on LLP64), the first
     // post-wrap frame records normally and self-corrects via the decay.)
-    if (m_iLastFrameTime != 0 && Time > m_iLastFrameTime && Time - m_iLastFrameTime > 250) {
+    if (m_bCalibrated && m_iLastFrameTime != 0 && Time > m_iLastFrameTime && Time - m_iLastFrameTime > 250) {
         const unsigned long gap = Time - m_iLastFrameTime;
         if (m_iGuardedMs < kMaxGuardedMs) {
+            m_iGuardedMs += gap;
             m_iGuardedMs += gap;
             m_iTime = Time;
             m_iFrames = 0;
@@ -78,7 +79,14 @@ void CFrameRate::RecordFrame(unsigned long Time) {
         // sampling period
         if (m_iTime2 - m_iTime > 0) {
             // A completed window is evidence of a live cadence: forgive the
-            // suspension budget so future one-off stalls are guarded again.
+            // suspension budget so future one-off stalls are guarded again,
+            // and mark the estimator calibrated — a suspension only has an
+            // estimate to protect once one window has completed. Guarding
+            // the very first frames instead froze the initial calibration
+            // (CI: low_memory tests, whose first frame follows a >250ms gap
+            // from the pre-frame input stamp, never updated LP_FRAMERATE
+            // from its default and zoomed at half speed).
+            m_bCalibrated = true;
             m_iGuardedMs = 0;
             double dFrNow = m_iFrames * 1000.0 / (m_iTime2 - m_iTime);
             // LP_FRAMERATE records a decaying average, smoothed 50:50 with previous value

--- a/src/DasherCore/FrameRate.cpp
+++ b/src/DasherCore/FrameRate.cpp
@@ -47,7 +47,6 @@ void CFrameRate::RecordFrame(unsigned long Time) {
         const unsigned long gap = Time - m_iLastFrameTime;
         if (m_iGuardedMs < kMaxGuardedMs) {
             m_iGuardedMs += gap;
-            m_iGuardedMs += gap;
             m_iTime = Time;
             m_iFrames = 0;
             m_iLastFrameTime = Time;

--- a/src/DasherCore/FrameRate.cpp
+++ b/src/DasherCore/FrameRate.cpp
@@ -33,21 +33,29 @@ void CFrameRate::RecordFrame(unsigned long Time) {
     // the gap as a suspension: drop the partial window and keep the
     // pre-stall estimate. 250ms ≈ 15 dropped frames at 60fps — generous
     // enough never to trigger on scheduler jitter.
+    //
+    // Budget, not counter: guarded gap time accumulates and is only
+    // forgiven when a measurement window COMPLETES. A counter reset by any
+    // single normal frame would freeze the estimate under bursty
+    // throttling (≤3 long gaps + 1 normal frame repeating — the timer-
+    // coalescing shape). Once ~1s has been discarded without a completed
+    // window, long gaps are recorded and the estimate adapts to the real
+    // cadence, however bursty. (Monotonicity is assumed; on platforms
+    // where unsigned long wraps (~49.7 days of ms on LLP64), the first
+    // post-wrap frame records normally and self-corrects via the decay.)
     if (m_iLastFrameTime != 0 && Time > m_iLastFrameTime && Time - m_iLastFrameTime > 250) {
-        if (m_iSuspensions < kMaxConsecutiveSuspensions) {
-            m_iSuspensions++;
+        const unsigned long gap = Time - m_iLastFrameTime;
+        if (m_iGuardedMs < kMaxGuardedMs) {
+            m_iGuardedMs += gap;
             m_iTime = Time;
             m_iFrames = 0;
             m_iLastFrameTime = Time;
             return;
         }
-        // Third-and-later long gaps in a row: this is not an interrupted
-        // cadence, it IS the cadence (a frontend genuinely rendering below
-        // ~4fps). Let the frame record normally so LP_FRAMERATE adapts to
-        // reality — otherwise Steps() stays tuned for a framerate the
-        // frontend no longer achieves and text entry stalls.
-    } else {
-        m_iSuspensions = 0; // a normal-gap frame re-arms the guard
+        // Budget exhausted without a completed window: this is not an
+        // interrupted cadence, it IS the cadence. Record the frame so
+        // LP_FRAMERATE adapts — otherwise Steps() stays tuned for a
+        // framerate the frontend no longer achieves and text entry stalls.
     }
     m_iLastFrameTime = Time;
 
@@ -69,6 +77,9 @@ void CFrameRate::RecordFrame(unsigned long Time) {
         // Calculate the framerate and reset framerate statistics for next
         // sampling period
         if (m_iTime2 - m_iTime > 0) {
+            // A completed window is evidence of a live cadence: forgive the
+            // suspension budget so future one-off stalls are guarded again.
+            m_iGuardedMs = 0;
             double dFrNow = m_iFrames * 1000.0 / (m_iTime2 - m_iTime);
             // LP_FRAMERATE records a decaying average, smoothed 50:50 with previous value
             m_pSettingsStore->SetLongParameter(

--- a/src/DasherCore/FrameRate.cpp
+++ b/src/DasherCore/FrameRate.cpp
@@ -23,6 +23,24 @@ CFrameRate::~CFrameRate() {
 }
 
 void CFrameRate::RecordFrame(unsigned long Time) {
+    // Suspension guard (Dasher-Android #35): if the previous frame was a
+    // long time ago, the process was stalled (GC pause, OS throttling of a
+    // floating IME, occlusion, debugger). Frames are constant-pace zoom
+    // steps, so the stall itself does no zoom catch-up — but folding the
+    // wall-clock gap into this sampling window would collapse the
+    // framerate estimate, shrink Steps(), and make every post-stall frame
+    // zoom a large fraction at once ("lags, then the letters jump"). Treat
+    // the gap as a suspension: drop the partial window and keep the
+    // pre-stall estimate. 250ms ≈ 15 dropped frames at 60fps — generous
+    // enough never to trigger on scheduler jitter.
+    if (m_iLastFrameTime != 0 && Time > m_iLastFrameTime && Time - m_iLastFrameTime > 250) {
+        m_iTime = Time;
+        m_iFrames = 0;
+        m_iLastFrameTime = Time;
+        return;
+    }
+    m_iLastFrameTime = Time;
+
     m_iFrames++;
 
     // Update values once enough samples have been collected

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -42,13 +42,19 @@ class CFrameRate {
         // An intentional pause must not be charged as a suspension when
         // recording resumes (and must NOT be zeroed: the first resumed
         // frame would otherwise fold the pause gap into the fresh window).
-        // The guard budget is deliberately NOT cleared here: stale-stamped
-        // input events (t≈1, queued before the first frame) re-trigger
-        // run()/Reset_framerate on every frame in some frontends/tests, and
-        // a budget reset there would re-arm the guard infinitely, freezing
-        // LP_FRAMERATE at its default (CI: low_memory tests produced no
-        // text). With the budget retained, the second stale gap is already
-        // recorded and the estimate converges.
+        //
+        // The guard budget is cleared ONLY for forward-time resets: a
+        // genuine pause deserves fresh suspension protection for the
+        // resumed segment — without this, a session that exhausted the
+        // budget (bursty throttling), paused, then hit one stall before
+        // the resumed window completed would record that stall unguarded
+        // and collapse the estimate (review finding). Backwards-stamped
+        // resets are the harness pathology where stale input events
+        // (t≈1, queued before the first frame) re-trigger run() every
+        // frame — clearing there re-armed the guard infinitely and froze
+        // LP_FRAMERATE at its default (CI: low_memory tests). Time moving
+        // backwards is never a real pause.
+        if (Time >= m_iLastFrameTime) m_iGuardedMs = 0;
         m_iLastFrameTime = Time;
     }
 

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -53,6 +53,12 @@ class CFrameRate {
     /// of a background IME, debugger pause) — the wall-clock gap must not
     /// be folded into the framerate estimate (Dasher-Android #35).
     unsigned long m_iLastFrameTime = 0;
+    /// consecutive >250ms gaps seen without a normal frame between them.
+    /// A stall is an outlier; a sustained run of long gaps is a real slow
+    /// cadence and must be measured, so only the first few are treated as
+    /// suspensions.
+    int m_iSuspensions = 0;
+    static constexpr int kMaxConsecutiveSuspensions = 3;
     /// number of frames over which we will compute average framerate
     int m_iSamples;
 

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -39,6 +39,10 @@ class CFrameRate {
     void Reset_framerate(unsigned long Time) {
         m_iFrames = 0;
         m_iTime = Time;
+        // An intentional pause must not be charged as a suspension when
+        // recording resumes (and must NOT be zeroed: the first resumed
+        // frame would otherwise fold the pause gap into the fresh window).
+        m_iLastFrameTime = Time;
     }
 
     void RecordFrame(unsigned long Time);
@@ -53,12 +57,16 @@ class CFrameRate {
     /// of a background IME, debugger pause) — the wall-clock gap must not
     /// be folded into the framerate estimate (Dasher-Android #35).
     unsigned long m_iLastFrameTime = 0;
-    /// consecutive >250ms gaps seen without a normal frame between them.
-    /// A stall is an outlier; a sustained run of long gaps is a real slow
-    /// cadence and must be measured, so only the first few are treated as
-    /// suspensions.
-    int m_iSuspensions = 0;
-    static constexpr int kMaxConsecutiveSuspensions = 3;
+    /// total wall-clock time (ms) discarded by the suspension guard since
+    /// the last COMPLETED measurement window. A stall is an outlier, but a
+    /// sustained or bursty pattern of long gaps is a real slow cadence and
+    /// must be measured — so at most ~1s of gap time is discardable per
+    /// window; beyond that the gaps are recorded and the estimate adapts.
+    /// (A counter reset by any single normal frame would freeze the
+    /// estimate under bursty throttling: ≤3 long gaps + 1 normal frame,
+    /// repeating — the classic timer-coalescing shape.)
+    unsigned long m_iGuardedMs = 0;
+    static constexpr unsigned long kMaxGuardedMs = 1000;
     /// number of frames over which we will compute average framerate
     int m_iSamples;
 

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -48,6 +48,11 @@ class CFrameRate {
     int m_iFrames;
     /// time at which first sampled frame was rendered
     unsigned long m_iTime;
+    /// time at which the previous frame was recorded. A long gap between
+    /// frames means the process was suspended or starved (GC, OS throttling
+    /// of a background IME, debugger pause) — the wall-clock gap must not
+    /// be folded into the framerate estimate (Dasher-Android #35).
+    unsigned long m_iLastFrameTime = 0;
     /// number of frames over which we will compute average framerate
     int m_iSamples;
 

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -42,8 +42,14 @@ class CFrameRate {
         // An intentional pause must not be charged as a suspension when
         // recording resumes (and must NOT be zeroed: the first resumed
         // frame would otherwise fold the pause gap into the fresh window).
+        // The guard budget is deliberately NOT cleared here: stale-stamped
+        // input events (t≈1, queued before the first frame) re-trigger
+        // run()/Reset_framerate on every frame in some frontends/tests, and
+        // a budget reset there would re-arm the guard infinitely, freezing
+        // LP_FRAMERATE at its default (CI: low_memory tests produced no
+        // text). With the budget retained, the second stale gap is already
+        // recorded and the estimate converges.
         m_iLastFrameTime = Time;
-        m_iGuardedMs = 0; // a fresh session starts with a full budget
     }
 
     void RecordFrame(unsigned long Time);
@@ -71,6 +77,10 @@ class CFrameRate {
     /// the estimate, trading slow-cadence tracking for smoothness.
     unsigned long m_iGuardedMs = 0;
     static constexpr unsigned long kMaxGuardedMs = 1000;
+    /// true once at least one sampling window has completed — i.e. an
+    /// estimate exists to protect. Long gaps before that are part of
+    /// initial calibration and are recorded, not guarded.
+    bool m_bCalibrated = false;
     /// number of frames over which we will compute average framerate
     int m_iSamples;
 

--- a/src/DasherCore/FrameRate.h
+++ b/src/DasherCore/FrameRate.h
@@ -43,6 +43,7 @@ class CFrameRate {
         // recording resumes (and must NOT be zeroed: the first resumed
         // frame would otherwise fold the pause gap into the fresh window).
         m_iLastFrameTime = Time;
+        m_iGuardedMs = 0; // a fresh session starts with a full budget
     }
 
     void RecordFrame(unsigned long Time);
@@ -64,7 +65,10 @@ class CFrameRate {
     /// window; beyond that the gaps are recorded and the estimate adapts.
     /// (A counter reset by any single normal frame would freeze the
     /// estimate under bursty throttling: ≤3 long gaps + 1 normal frame,
-    /// repeating — the classic timer-coalescing shape.)
+    /// repeating — the classic timer-coalescing shape.) Deliberate blind
+    /// spot: stall clusters interleaved with a full window of normal
+    /// frames are forgiven entirely — repeated outliers never degrade
+    /// the estimate, trading slow-cadence tracking for smoothness.
     unsigned long m_iGuardedMs = 0;
     static constexpr unsigned long kMaxGuardedMs = 1000;
     /// number of frames over which we will compute average framerate

--- a/tests/test_framerate.cpp
+++ b/tests/test_framerate.cpp
@@ -155,6 +155,44 @@ TEST(framerate_251ms_boundary_is_measured) {
     ASSERT(after < before / 2); // ~4fps measured, not frozen at 62fps
 }
 
+TEST(framerate_pause_restores_an_exhausted_budget) {
+    // Review finding: a session that exhausts the guard budget (bursty
+    // throttling), pauses, then stalls once before the resumed window
+    // completes — that stall must still be guarded. A genuine pause is a
+    // forward-time Reset_framerate and restores the budget; only the
+    // backwards-stamped harness pathology (stale t≈1 input events) must
+    // not (it would re-arm the guard infinitely — the low_memory CI
+    // failure).
+    FramerateFixture f;
+    f.feed(200, 1000, 16); // calibrated at ~62fps
+    const long before = f.lpFramerate();
+
+    // Exhaust the budget with bursty long gaps, never completing a window.
+    unsigned long t = 5000;
+    for (int burst = 0; burst < 3; burst++) {
+        f.feed(1, t, 1);
+        t += 300; // gap guarded, budget 300/600/900
+    }
+    // Genuine pause: forward-time reset, then ONE stall soon after resume
+    // (before any window completes — 3 frames aren't enough at these
+    // sample counts).
+    f.framerate->Reset_framerate(20000);
+    f.feed(1, 20000, 1);
+    f.feed(1, 20700, 1);   // 700ms stall
+    f.feed(60, 20716, 16); // recovery
+    const long afterPauseStall = f.lpFramerate();
+    printf("  exhausted budget + pause + one stall: before=%ld after=%ld\n", before, afterPauseStall);
+    ASSERT(afterPauseStall > before * 4 / 5); // stall was guarded, no collapse
+
+    // The harness pathology must NOT restore the budget: a stale
+    // backwards stamp (t=1 while frames run at ~30k) leaves it exhausted.
+    f.framerate->Reset_framerate(1);
+    f.feed(1, 30000, 1); // giant fake gap — recorded (budget still low), not guarded
+    // (No assertion on the estimate here — recording is correct for a
+    // budget-exhausted session; the point is the guard does not re-arm:
+    // verified by the low_memory suite passing.)
+}
+
 TEST(framerate_scheduler_jitter_is_not_a_suspension) {
     FramerateFixture f;
     f.feed(200, 1000, 16);

--- a/tests/test_framerate.cpp
+++ b/tests/test_framerate.cpp
@@ -77,8 +77,9 @@ TEST(framerate_stall_recovers_without_overshoot) {
     f.feed(400, 5000, 16);
     const long after = f.lpFramerate();
     printf("  steady after stall: before=%ld after=%ld\n", before, after);
-    ASSERT(after > before / 2);
-    ASSERT(after < before * 2);
+    // Tight band: the estimate re-converges to the same cadence, ±20%.
+    ASSERT(after > before * 4 / 5);
+    ASSERT(after < before * 6 / 5);
 }
 
 TEST(framerate_sustained_slow_cadence_is_still_measured) {
@@ -96,16 +97,70 @@ TEST(framerate_sustained_slow_cadence_is_still_measured) {
     ASSERT(after < before / 2); // adapted well down toward the real rate
 }
 
+TEST(framerate_bursty_throttling_is_eventually_measured) {
+    // Review probe: <=3 long gaps + 1 normal frame, repeating (~4.4fps
+    // effective — the classic timer-coalescing / IME-throttling shape).
+    // A counter re-armed by any normal frame froze the estimate at 62fps
+    // forever under this pattern; the time-weighted budget must let the
+    // cadence through.
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    unsigned long t = 5000;
+    for (int burst = 0; burst < 60; burst++) {
+        for (int i = 0; i < 3; i++) {
+            f.feed(1, t, 1);
+            t += 300; // long gap after this frame
+        }
+        f.feed(1, t, 1);
+        t += 16; // the lone normal frame
+    }
+    const long after = f.lpFramerate();
+    printf("  bursty 3x300+16ms pattern: before=%ld after=%ld\n", before, after);
+    ASSERT(after < before / 2); // the ~4.4fps reality got measured
+}
+
+TEST(framerate_intentional_pause_survives_reset_framerate) {
+    // Reset_framerate (engine pause) sets m_iLastFrameTime, so a long
+    // intentional pause is not a suspension and — critically — is not
+    // folded into the fresh window either. Pins the Reset_framerate
+    // interaction the review asked about.
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    f.framerate->Reset_framerate(60000); // 56s pause while unpaused engine
+    f.feed(60, 60000, 16);
+    const long after = f.lpFramerate();
+    printf("  after 56s pause via Reset_framerate: before=%ld after=%ld\n", before, after);
+    ASSERT(after > before * 4 / 5);
+    ASSERT(after < before * 6 / 5);
+}
+
+TEST(framerate_251ms_boundary_is_measured) {
+    // 251ms > 250ms threshold: guarded at first, but the budget must let
+    // the true ~4fps cadence through (boundary probe from the review).
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    f.feed(120, 5000, 251);
+    const long after = f.lpFramerate();
+    printf("  steady 251ms cadence: before=%ld after=%ld\n", before, after);
+    ASSERT(after < before / 2); // ~4fps measured, not frozen at 62fps
+}
+
 TEST(framerate_scheduler_jitter_is_not_a_suspension) {
     FramerateFixture f;
     f.feed(200, 1000, 16);
     const long before = f.lpFramerate();
 
-    // Normal jitter — occasional 100ms hiccup — must still be measured
-    // (this is genuinely slow rendering, not a suspension).
+    // Genuinely slow rendering (216ms gaps between 16ms frame pairs —
+    // ~8.6fps effective, every gap under the 250ms threshold) must still
+    // be measured: this is a slow cadence, not a suspension.
     for (int i = 0; i < 60; i++) {
         f.feed(2, 10000 + i * 232, 16);
-        // (2 frames per 232ms window ≈ 8.6fps average)
     }
     const long after = f.lpFramerate();
     printf("  genuine slowdown measured: before=%ld after=%ld\n", before, after);

--- a/tests/test_framerate.cpp
+++ b/tests/test_framerate.cpp
@@ -122,18 +122,22 @@ TEST(framerate_bursty_throttling_is_eventually_measured) {
 }
 
 TEST(framerate_intentional_pause_survives_reset_framerate) {
-    // Reset_framerate (engine pause) sets m_iLastFrameTime, so a long
-    // intentional pause is not a suspension and — critically — is not
-    // folded into the fresh window either. Pins the Reset_framerate
-    // interaction the review asked about.
+    // Reset_framerate (engine pause) stamps m_iLastFrameTime and clears
+    // the guard budget. The discriminating sequence (loop-3 review): a
+    // 56s pause followed by a genuine 700ms stall. Without the stamp,
+    // the pause gap would be folded into the fresh window (estimate
+    // collapses); without the budget clear, the stall would land on an
+    // exhausted budget and fold in too. With both, the estimate survives.
     FramerateFixture f;
     f.feed(200, 1000, 16);
     const long before = f.lpFramerate();
 
-    f.framerate->Reset_framerate(60000); // 56s pause while unpaused engine
-    f.feed(60, 60000, 16);
+    f.framerate->Reset_framerate(60000); // 56s intentional pause
+    f.feed(20, 60000, 16);               // resumed session running normally
+    f.feed(1, 60320 + 700, 1);           // a genuine 700ms stall mid-session
+    f.feed(60, 61036, 16);               // and recovery
     const long after = f.lpFramerate();
-    printf("  after 56s pause via Reset_framerate: before=%ld after=%ld\n", before, after);
+    printf("  pause + stall + recover: before=%ld after=%ld\n", before, after);
     ASSERT(after > before * 4 / 5);
     ASSERT(after < before * 6 / 5);
 }

--- a/tests/test_framerate.cpp
+++ b/tests/test_framerate.cpp
@@ -1,0 +1,98 @@
+// Frame-rate estimation regression tests.
+//
+// Dasher-Android #35: in the floating-keyboard IME the process gets briefly
+// starved (overlay IMEs are low priority); on resume the wall-clock gap was
+// folded into CFrameRate's sampling window, collapsing LP_FRAMERATE,
+// shrinking Steps(), and making every post-stall frame zoom a large
+// fraction at once — "lags, then the letters jump". The suspension guard
+// treats a >250ms inter-frame gap as a pause: the partial window is dropped
+// and the pre-stall estimate survives.
+#include "test_common.h"
+
+#include "DasherCore/FrameRate.h"
+#include "DasherCore/Parameters.h"
+#include "DasherCore/SettingsStore.h"
+
+#include <memory>
+
+using namespace Dasher;
+
+namespace {
+
+struct FramerateFixture {
+    CSettingsStore store;
+    std::unique_ptr<CFrameRate> framerate;
+
+    FramerateFixture() {
+        // A bare CSettingsStore starts with an empty parameter table, and
+        // CFrameRate's ctor reads LP_X_LIMIT_SPEED from it — populate from
+        // the manifest FIRST (as the engine does on startup), then build.
+        store.AddParameters(Settings::parameter_defaults);
+        framerate = std::make_unique<CFrameRate>(&store);
+    }
+
+    long lpFramerate() const { return store.GetLongParameter(LP_FRAMERATE); }
+
+    // Feed frames at the given cadence starting at Time.
+    void feed(int count, unsigned long startMs, unsigned long stepMs) {
+        for (int i = 0; i < count; i++)
+            framerate->RecordFrame(startMs + i * stepMs);
+    }
+};
+
+} // namespace
+
+TEST(framerate_steady_60fps_estimates_around_60) {
+    FramerateFixture f;
+    // LP_FRAMERATE default is 2500 (25fps in hundredths); drive it to ~60.
+    f.feed(200, 1000, 16);
+    printf("  LP_FRAMERATE after 200 @16ms: %ld\n", f.lpFramerate());
+    ASSERT(f.lpFramerate() > 4000); // ≈40fps+ — the estimate tracked reality
+}
+
+TEST(framerate_stall_does_not_collapse_the_estimate) {
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    // 600ms suspension (float-IME throttling / GC), then frames resume.
+    // Last pre-stall frame is at 1000 + 199*16 = 4184ms; resume at 5000ms.
+    f.feed(60, 5000, 16);
+    const long after = f.lpFramerate();
+    printf("  LP_FRAMERATE before stall: %ld, after stall+resume: %ld\n", before, after);
+
+    // Without the guard the estimate collapsed toward ~3fps (a frame pair
+    // spanning the 600ms gap), shrinking Steps() and making every
+    // post-stall frame a mega-zoom. With it, the estimate survives.
+    ASSERT(after >= before * 9 / 10);
+}
+
+TEST(framerate_stall_recovers_without_overshoot) {
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    // A stall, then a long steady run at the same real cadence: the estimate
+    // must stay near the pre-stall value (no collapse, no runaway growth).
+    f.feed(400, 5000, 16);
+    const long after = f.lpFramerate();
+    printf("  steady after stall: before=%ld after=%ld\n", before, after);
+    ASSERT(after > before / 2);
+    ASSERT(after < before * 2);
+}
+
+TEST(framerate_scheduler_jitter_is_not_a_suspension) {
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    // Normal jitter — occasional 100ms hiccup — must still be measured
+    // (this is genuinely slow rendering, not a suspension).
+    for (int i = 0; i < 60; i++) {
+        f.feed(2, 10000 + i * 232, 16);
+        // (2 frames per 232ms window ≈ 8.6fps average)
+    }
+    const long after = f.lpFramerate();
+    printf("  genuine slowdown measured: before=%ld after=%ld\n", before, after);
+    ASSERT(after < before * 3 / 4); // the estimate did track the slowdown
+}

--- a/tests/test_framerate.cpp
+++ b/tests/test_framerate.cpp
@@ -81,6 +81,21 @@ TEST(framerate_stall_recovers_without_overshoot) {
     ASSERT(after < before * 2);
 }
 
+TEST(framerate_sustained_slow_cadence_is_still_measured) {
+    FramerateFixture f;
+    f.feed(200, 1000, 16);
+    const long before = f.lpFramerate();
+
+    // A frontend genuinely rendering at ~3.3fps (300ms/frame): the first
+    // few long gaps are treated as suspensions, but the cadence must then
+    // be measured — otherwise Steps() stays tuned for 60fps and text entry
+    // stalls at the true bit-rate's fraction (review finding on the guard).
+    f.feed(200, 5000, 300);
+    const long after = f.lpFramerate();
+    printf("  sustained 3.3fps: before=%ld after=%ld\n", before, after);
+    ASSERT(after < before / 2); // adapted well down toward the real rate
+}
+
 TEST(framerate_scheduler_jitter_is_not_a_suspension) {
     FramerateFixture f;
     f.feed(200, 1000, 16);


### PR DESCRIPTION
## Root cause — Dasher-Android #35 (floating-keyboard IME lag-then-jump)

Frames are constant-pace zoom steps, so a render stall does no catch-up by itself. But `CFrameRate::RecordFrame` folded the wall-clock gap into its sampling window:

1. Float-IME process gets briefly starved (overlay IMEs are low priority; GC; target-app contention)
2. On resume the window's elapsed time includes the stall → fps estimate collapses
3. `m_iSamples--` (toward 2) makes the next recompute span the gap again — compounding
4. `LP_FRAMERATE` decays → `Steps()` (bit-rate constant derived from it) shrinks → **every post-stall frame zooms a large fraction at once**
5. The 50:50 decaying average recovers slowly → sustained over-zoom → *"you have to zoom back a tiny bit so you can pick the right letters"*

Same victim as the restart mega-jumps fixed in v0.2.7 (#61), different trigger: mid-run stalls instead of stop/restart re-seeding. Engine-side, so it hardens every frontend (GC pauses on Android, occlusion on desktop, debugger stops everywhere).

## Fix

`RecordFrame` treats an inter-frame gap **>250ms** (~15 dropped frames at 60fps — never hit by scheduler jitter) as a suspension: drop the partial sampling window, keep the pre-stall estimate. Zoom resumes at the pre-stall pace instead of leaping.

## Tests (new `test_framerate.cpp`)

| case | result |
|---|---|
| steady 60fps | estimate tracks (→ ~62fps) |
| 600ms stall + resume | estimate survives **exactly** (6249 → 6249; collapses without the guard) |
| long steady run after stall | stable, no overshoot |
| genuine sustained slowdown (100ms gaps) | **still measured** (6249 → 862) — the guard doesn't mask real slowness |

Note for reviewers: the fixture populates the store from `Settings::parameter_defaults` before constructing `CFrameRate`, matching engine startup order — the ctor reads `LP_X_LIMIT_SPEED` immediately.













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents isolated frame stalls from collapsing the smoothed frame-rate estimate while retaining adaptation to genuinely slow or bursty rendering.
- Adds a bounded suspension-time budget and resets partial sampling windows around isolated stalls.
- Restores suspension protection across forward-time pause resets without repeatedly rearming it for stale backward timestamps.
- Adds direct internal regression coverage for steady, stalled, slow, bursty, boundary, and reset timing patterns.
- Links the frame-rate test directly against the internal static core so its C++ symbols are available on MSVC.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CMakeLists.txt | Registers the frame-rate regression target through the internal-test helper, directly linking the static core and resolving the previously reported MSVC symbol failure. |
| src/DasherCore/FrameRate.cpp | Implements bounded suspension filtering, eventual slow-cadence sampling, and budget restoration after completed measurement windows; the previously reported cadence and accounting defects are addressed. |
| src/DasherCore/FrameRate.h | Adds estimator calibration and suspension-budget state and restores the budget for genuine forward-time resets, addressing the prior pause/reset finding. |
| tests/test_framerate.cpp | Adds focused regression cases for steady timing, isolated stalls, sustained and bursty slowdown, threshold behavior, and reset lifecycle handling. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    F[Record frame] --> G{Calibrated gap over 250 ms?}
    G -- No --> S[Sample frame normally]
    G -- Yes --> B{Guard budget available?}
    B -- Yes --> D[Discard partial window and preserve estimate]
    B -- No --> S
    S --> W{Sampling window complete?}
    W -- No --> F
    W -- Yes --> U[Update smoothed frame rate]
    U --> R[Clear guarded-time budget]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: a genuine pause restores an exhaust..."](https://github.com/dasher-project/dashercore/commit/9ea110577e039f53f279bd6c282d435254e118fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60703159)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Model, view, and rendering geometry](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/model-view-rendering.md)
- Knowledge Base — [Integration, build, and quality](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/integration-build-and-quality.md)
- Knowledge Base — [Automated testing](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/automated-testing.md)
</details>


<!-- /greptile_comment -->