### PR TITLE
fix: draw node outlines by default (v5 parity)

### DIFF
--- a/settings_manifest.json
+++ b/settings_manifest.json
@@ -894,7 +894,7 @@
       "key": "LP_OUTLINE_WIDTH",
       "storageName": "OutlineWidth",
       "type": "long",
-      "default": 0,
+      "default": 1,
       "label": "Outline Width",
       "description": "Absolute value is line width to draw boxes (fill iff >=0).",
       "uiType": "Step",

--- a/src/DasherCore/Parameters.cpp
+++ b/src/DasherCore/Parameters.cpp
@@ -330,7 +330,7 @@ const std::unordered_map<Parameter, const Parameter_Value> parameter_defaults = 
                      "Target (min) number of node objects to maintain.", "Node Budget", Settings::UIControlType::Step,
                      100, 10000, 1, 100, true, "LP_NODE_BUDGET", "Advanced", "Input"}},
 #endif
-    {LP_OUTLINE_WIDTH, Parameter_Value{"OutlineWidth", PARAM_LONG, Persistence::PERSISTENT, 0l,
+    {LP_OUTLINE_WIDTH, Parameter_Value{"OutlineWidth", PARAM_LONG, Persistence::PERSISTENT, 1l,
                                        "Absolute value is line width to draw boxes (fill iff >=0).", "Outline Width",
                                        Settings::UIControlType::Step, -10, 100, 1, 1, true, "LP_OUTLINE_WIDTH",
                                        "Appearance", "Customization"}},


### PR DESCRIPTION
Fixes the visual half of [Dasher-GTK #80](https://github.com/dasher-project/Dasher-GTK/issues/80) (*"yellow letters floating in space, difficult to differentiate where the borders are"* + the *"vertical bar on the right side"*).

## Root cause
The v6 palettes are outline-based by design: e.g. **Yellow on Black** fills every node box with the background colour (`#181712`) and the space node with a flat `#000000` slab — visibility comes entirely from the palette's `defaultOutlineColor`. With `LP_OUTLINE_WIDTH` defaulting to **0**, no outlines are drawn: boxes are invisible (letters float), and large flat nodes read as mystery vertical slabs at the canvas edge.

v5 drew outlines by default. The v5→v6 conversion lost that in the default.

## Change
`LP_OUTLINE_WIDTH` default `0 → 1` — every box gets its palette outline colour (1px, grey `#636363` on Yellow on Black; the legacy palettes all define one). Users who explicitly set the value keep theirs; installs that never touched it (the setting absent from `dasher_settings.xml`) pick up the new default.

Note: takes effect for a user only when their persisted settings lack `OutlineWidth` — users who deliberately set 0 keep 0.

Affects all frontends (GTK/Windows/Apple/Android/web) on fresh installs — matching v5 behaviour across the board.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores one-pixel node outlines as the default for installations without a persisted `OutlineWidth` value.
- Changes `LP_OUTLINE_WIDTH` from 0 to 1 in the authoritative settings manifest.
- Keeps the generated C++ parameter table synchronized with the manifest.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| settings_manifest.json | Changes the authoritative `LP_OUTLINE_WIDTH` default to 1 for new or unset configurations. |
| src/DasherCore/Parameters.cpp | Updates the generated runtime parameter default to match the manifest. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: sync the outline default into the s..."](https://github.com/dasher-project/dashercore/commit/8868648aa366607b42aef820e63a989560afec83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60724063)</sub>

**Context used:**

- Knowledge Base — [Configuration and content](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/configuration-and-content.md)
- Knowledge Base — [Settings and parameter management](https://app.greptile.com/dasher-project/-/custom-context/knowledge-base/dasher-project/dashercore/-/docs/settings-and-parameter-management.md)

<!-- /greptile_comment -->