### PR TITLE
feat(capi): dasher_set_offset + dasher_seed_buffer — context awareness (RFC 0015)

### DIFF
--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2107,6 +2107,74 @@ DASHER_API int dasher_get_offset(dasher_ctx* ctx) {
     return model->GetOffset();
 }
 
+// ── Context awareness (RFC 0015) ──────────────────────────────────────────
+
+// Realize on demand: seeding/re-anchoring can happen when a direct-entry
+// frontend reads the target field before the first frame (e.g. on mode
+// entry). Mirrors the deferred-Realize handling dasher_set_palette uses.
+static bool ensure_realized_for_context(dasher_ctx* ctx) {
+    if (ctx->realized) return true;
+    if (!ctx->screen) return false;
+    try {
+        ctx->intf->Realize(nowMs());
+        ctx->realized = true;
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset) {
+    if (!ctx || !ctx->intf) return -1;
+    if (offset < 0) return -1;
+    if (!ensure_realized_for_context(ctx)) return -1;
+    try {
+        // offset is a byte-ish position into the edit buffer by historical
+        // convention (v5 used EDIT-control character offsets against UTF-8
+        // strings); clamp to the buffer so out-of-range values anchor at
+        // the end rather than asserting.
+        const auto clamped = std::min(static_cast<size_t>(offset), ctx->editBuffer.size());
+        ctx->cursorPos = clamped;
+        ctx->intf->SetOffset(static_cast<unsigned int>(clamped), true);
+        return 0;
+    } catch (const std::exception& e) {
+        log_boundary_error(ctx, "dasher_set_offset", e.what());
+        return -1;
+    } catch (...) {
+        log_boundary_error(ctx, "dasher_set_offset", "unknown exception");
+        return -1;
+    }
+}
+
+DASHER_API int dasher_seed_buffer(dasher_ctx* ctx, const char* text, int caret_offset) {
+    if (!ctx || !ctx->intf) return -1;
+    if (!ensure_realized_for_context(ctx)) return -1;
+    try {
+        // Replace the buffer with the target field's text.
+        ctx->editBuffer.assign(text ? text : "");
+        const auto clamped = std::min(static_cast<size_t>(std::max(caret_offset, 0)), ctx->editBuffer.size());
+        ctx->cursorPos = clamped;
+        ctx->rateTimestamps.clear();
+
+        // Subscribers must resync their mirrors WITHOUT injecting (RFC 0015:
+        // backspacing a whole field into the target would destroy the user's
+        // text — the same reasoning as Dasher-Windows #45's event-2 contract).
+        notify_buffer_cleared(ctx);
+
+        // Rebuild the model anchored at the caret: GetRoot seeds the LM from
+        // GetContext (the CAPI Interface reads ctx->editBuffer), so
+        // predictions continue from the text before the caret.
+        ctx->intf->SetOffset(static_cast<unsigned int>(clamped), true);
+        return 0;
+    } catch (const std::exception& e) {
+        log_boundary_error(ctx, "dasher_seed_buffer", e.what());
+        return -1;
+    } catch (...) {
+        log_boundary_error(ctx, "dasher_seed_buffer", "unknown exception");
+        return -1;
+    }
+}
+
 // ── Custom rendering, Strand 2 (RFC 0013) ──────────────────────────────────
 
 DASHER_API int dasher_set_visible_nodes_enabled(dasher_ctx* ctx, int enabled) {

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2124,16 +2124,38 @@ static bool ensure_realized_for_context(dasher_ctx* ctx) {
     }
 }
 
+// Clamp a caret offset for anchoring: clamp to the buffer, then snap DOWN
+// to the start of the containing codepoint. Offsets are UTF-8 bytes (the
+// buffer's unit, matching GetContext/edit-output everywhere else in this
+// CAPI), but platform carets arrive in character/UTF-16 units — a raw
+// conversion can land mid-sequence, which would corrupt every subsequent
+// edit. Snapping backward keeps the straddled codepoint in the pre-caret
+// context rather than dropping it (greptile #83: "caret offsets split
+// UTF-8"). Frontends should still convert UTF-16 -> UTF-8 properly; this is
+// the guard that makes a sloppy conversion degrade instead of corrupt.
+static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset) {
+    if (offset <= 0) return 0;
+    const auto size = static_cast<ptrdiff_t>(buf.size());
+    if (offset >= size) return buf.size();
+    size_t pos = static_cast<size_t>(offset);
+    int back = 0;
+    while (pos > 0 && (static_cast<unsigned char>(buf[pos]) & 0xC0) == 0x80 && back < 3) {
+        --pos;
+        ++back;
+    }
+    return pos;
+}
+
 DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset) {
     if (!ctx || !ctx->intf) return -1;
     if (offset < 0) return -1;
     if (!ensure_realized_for_context(ctx)) return -1;
     try {
-        // offset is a byte-ish position into the edit buffer by historical
-        // convention (v5 used EDIT-control character offsets against UTF-8
-        // strings); clamp to the buffer so out-of-range values anchor at
-        // the end rather than asserting.
-        const auto clamped = std::min(static_cast<size_t>(offset), ctx->editBuffer.size());
+        // Offsets are UTF-8 byte positions into the edit buffer (the CAPI's
+        // universal unit); mid-sequence values from platform caret
+        // conversions snap down to the codepoint start instead of
+        // corrupting subsequent output (see clamp_caret_to_codepoint).
+        const auto clamped = clamp_caret_to_codepoint(ctx->editBuffer, offset);
         ctx->cursorPos = clamped;
         ctx->intf->SetOffset(static_cast<unsigned int>(clamped), true);
         return 0;
@@ -2152,7 +2174,11 @@ DASHER_API int dasher_seed_buffer(dasher_ctx* ctx, const char* text, int caret_o
     try {
         // Replace the buffer with the target field's text.
         ctx->editBuffer.assign(text ? text : "");
-        const auto clamped = std::min(static_cast<size_t>(std::max(caret_offset, 0)), ctx->editBuffer.size());
+        // caret_offset is a UTF-8 byte position; platform caret units
+        // (characters / UTF-16) must be converted by the frontend, and a
+        // mid-codepoint value snaps down rather than corrupting output
+        // (see clamp_caret_to_codepoint).
+        const auto clamped = clamp_caret_to_codepoint(ctx->editBuffer, caret_offset);
         ctx->cursorPos = clamped;
         ctx->rateTimestamps.clear();
 

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2153,6 +2153,18 @@ static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset)
 // resolves to the pair's start (the boundary BEFORE the second unit).
 // Malformed sequences degrade byte-per-byte (each stray byte = one
 // codepoint = one UTF-16 unit), so conversion never runs off the text.
+// A lead byte's declared width is only real if the declared-1 following
+// bytes are actual continuations (and not NUL). Otherwise this is a stray
+// lead byte and degrades to ONE unit, so the walker re-examines the next
+// byte as a fresh unit — byte-per-byte, as documented (greptile #83:
+// "\xC2\x41" with offset 1 must be 1, not 2).
+static int ValidatedSequenceLength(const unsigned char* p, int declared) {
+    for (int i = 1; i < declared; ++i) {
+        if ((p[i] & 0xC0) != 0x80) return 1; // not a continuation (covers NUL)
+    }
+    return declared;
+}
+
 static int byte_offset_from_count(const char* utf8_text, int target, bool count_utf16) {
     if (!utf8_text) return -1;
     if (target <= 0) return 0;
@@ -2164,14 +2176,15 @@ static int byte_offset_from_count(const char* utf8_text, int target, bool count_
         // Lead-byte masks are mutually exclusive, so the check order is
         // free; grouping both one-unit cases (ASCII and stray
         // continuation/invalid) into the else keeps clang-tidy's
-        // branch-clone check happy.
+        // branch-clone check happy. Declared widths are validated — a
+        // truncated or corrupt sequence degrades to one stray byte.
         int cp_bytes;
         if ((c & 0xF8) == 0xF0)
-            cp_bytes = 4;
+            cp_bytes = ValidatedSequenceLength(p, 4);
         else if ((c & 0xF0) == 0xE0)
-            cp_bytes = 3;
+            cp_bytes = ValidatedSequenceLength(p, 3);
         else if ((c & 0xE0) == 0xC0)
-            cp_bytes = 2;
+            cp_bytes = ValidatedSequenceLength(p, 2);
         else
             cp_bytes = 1; // ASCII (< 0x80) or stray continuation/invalid
 

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2133,6 +2133,7 @@ static bool ensure_realized_for_context(dasher_ctx* ctx) {
 // context rather than dropping it. Frontends convert units with
 // dasher_byte_offset_from_utf16 / _from_codepoints; this is the guard that
 // makes a sloppy conversion degrade instead of corrupt.
+static int ValidatedSequenceLength(const unsigned char* p, int declared);
 static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset) {
     if (offset <= 0) return 0;
     const auto size = static_cast<ptrdiff_t>(buf.size());
@@ -2143,15 +2144,34 @@ static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset)
         --pos;
         ++back;
     }
-    // Verify the landing is a lead byte (or ASCII), not still inside a run
-    // of stray continuation bytes: with 4+ consecutive stray continuations
-    // the 3-step scan can land on another continuation, and a correctly
-    // converted boundary would be moved to the wrong byte (greptile #83
-    // follow-up). Under the byte-per-byte degradation contract every stray
-    // byte is its own unit, so the original position IS a valid boundary
-    // when the scan can't find a real lead byte.
+    if (back == 0) return pos; // already on a boundary
+    // Landing on buf[pos]. If it's still a continuation (long stray run),
+    // the original offset is a valid boundary (greptile: 4+ strays).
     if ((static_cast<unsigned char>(buf[pos]) & 0xC0) == 0x80) return static_cast<size_t>(offset);
-    return pos;
+    // The candidate lead byte at pos must form a VALID sequence with the
+    // continuation bytes we walked over. In a malformed run (e.g. the
+    // surrogate ED A0 80), the bytes look like lead + continuations but
+    // are semantically stray — byte 1 is already a valid boundary under
+    // the byte-per-byte contract, and snapping to 0 moves the anchor
+    // BEFORE the wrong prefix (greptile: "malformed-byte boundary snaps
+    // backward").
+    const auto* p = reinterpret_cast<const unsigned char*>(buf.data()) + pos;
+    unsigned char c = *p;
+    int declared;
+    if ((c & 0xF8) == 0xF0)
+        declared = 4;
+    else if ((c & 0xF0) == 0xE0)
+        declared = 3;
+    else if ((c & 0xE0) == 0xC0)
+        declared = 2;
+    else
+        declared = 1;
+    // If the lead isn't multi-byte, or declares fewer bytes than we walked
+    // over, those "continuations" are strays — don't snap.
+    if (declared <= 1 || declared < back + 1) return static_cast<size_t>(offset);
+    // Semantically validate: overlong, surrogate, above-range all reject.
+    if (ValidatedSequenceLength(p, declared) != declared) return static_cast<size_t>(offset);
+    return pos; // valid sequence — snap to its start
 }
 
 // Shared UTF-8 walker for the unit-conversion helpers: decodes text forward,

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2161,17 +2161,19 @@ static int byte_offset_from_count(const char* utf8_text, int target, bool count_
     int byte_pos = 0;
     while (*p) {
         unsigned char c = *p;
+        // Lead-byte masks are mutually exclusive, so the check order is
+        // free; grouping both one-unit cases (ASCII and stray
+        // continuation/invalid) into the else keeps clang-tidy's
+        // branch-clone check happy.
         int cp_bytes;
-        if (c < 0x80)
-            cp_bytes = 1;
-        else if ((c & 0xE0) == 0xC0)
-            cp_bytes = 2;
+        if ((c & 0xF8) == 0xF0)
+            cp_bytes = 4;
         else if ((c & 0xF0) == 0xE0)
             cp_bytes = 3;
-        else if ((c & 0xF8) == 0xF0)
-            cp_bytes = 4;
+        else if ((c & 0xE0) == 0xC0)
+            cp_bytes = 2;
         else
-            cp_bytes = 1; // stray continuation/invalid: degrade to one unit
+            cp_bytes = 1; // ASCII (< 0x80) or stray continuation/invalid
 
         // UTF-16 units for this codepoint: 2 if it encodes >= U+10000.
         const int units = (count_utf16 && cp_bytes == 4) ? 2 : 1;

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2130,9 +2130,9 @@ static bool ensure_realized_for_context(dasher_ctx* ctx) {
 // CAPI), but platform carets arrive in character/UTF-16 units — a raw
 // conversion can land mid-sequence, which would corrupt every subsequent
 // edit. Snapping backward keeps the straddled codepoint in the pre-caret
-// context rather than dropping it (greptile #83: "caret offsets split
-// UTF-8"). Frontends should still convert UTF-16 -> UTF-8 properly; this is
-// the guard that makes a sloppy conversion degrade instead of corrupt.
+// context rather than dropping it. Frontends convert units with
+// dasher_byte_offset_from_utf16 / _from_codepoints; this is the guard that
+// makes a sloppy conversion degrade instead of corrupt.
 static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset) {
     if (offset <= 0) return 0;
     const auto size = static_cast<ptrdiff_t>(buf.size());
@@ -2144,6 +2144,63 @@ static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset)
         ++back;
     }
     return pos;
+}
+
+// Shared UTF-8 walker for the unit-conversion helpers: decodes text forward,
+// tracking byte position, codepoint count and UTF-16 unit count, stopping
+// when the requested count is reached. count_utf16 selects the unit;
+// target < 0 clamps to 0; a UTF-16 target landing mid-surrogate-pair
+// resolves to the pair's start (the boundary BEFORE the second unit).
+// Malformed sequences degrade byte-per-byte (each stray byte = one
+// codepoint = one UTF-16 unit), so conversion never runs off the text.
+static int byte_offset_from_count(const char* utf8_text, int target, bool count_utf16) {
+    if (!utf8_text) return -1;
+    if (target <= 0) return 0;
+    long remaining = target;
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(utf8_text);
+    int byte_pos = 0;
+    while (*p) {
+        unsigned char c = *p;
+        int cp_bytes;
+        if (c < 0x80)
+            cp_bytes = 1;
+        else if ((c & 0xE0) == 0xC0)
+            cp_bytes = 2;
+        else if ((c & 0xF0) == 0xE0)
+            cp_bytes = 3;
+        else if ((c & 0xF8) == 0xF0)
+            cp_bytes = 4;
+        else
+            cp_bytes = 1; // stray continuation/invalid: degrade to one unit
+
+        // UTF-16 units for this codepoint: 2 if it encodes >= U+10000.
+        const int units = (count_utf16 && cp_bytes == 4) ? 2 : 1;
+        if (remaining < units) {
+            // UTF-16 target lands mid-surrogate-pair: resolve to the pair's
+            // start (the boundary before this codepoint's second unit).
+            break;
+        }
+        remaining -= units;
+        // Skip the codepoint's bytes (or one stray byte). NB: guard against
+        // running past NUL for truncated sequences — measure from the
+        // sequence start, never from the advancing pointer (p[i] would
+        // double-advance the lookahead and drop a byte).
+        const unsigned char* seq = p;
+        while (*p && (p - seq) < cp_bytes) {
+            ++p;
+            ++byte_pos;
+        }
+        if (remaining == 0) break;
+    }
+    return byte_pos;
+}
+
+DASHER_API int dasher_byte_offset_from_utf16(const char* utf8_text, int utf16_offset) {
+    return byte_offset_from_count(utf8_text, utf16_offset, true);
+}
+
+DASHER_API int dasher_byte_offset_from_codepoints(const char* utf8_text, int codepoint_offset) {
+    return byte_offset_from_count(utf8_text, codepoint_offset, false);
 }
 
 DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset) {

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -2143,6 +2143,14 @@ static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset)
         --pos;
         ++back;
     }
+    // Verify the landing is a lead byte (or ASCII), not still inside a run
+    // of stray continuation bytes: with 4+ consecutive stray continuations
+    // the 3-step scan can land on another continuation, and a correctly
+    // converted boundary would be moved to the wrong byte (greptile #83
+    // follow-up). Under the byte-per-byte degradation contract every stray
+    // byte is its own unit, so the original position IS a valid boundary
+    // when the scan can't find a real lead byte.
+    if ((static_cast<unsigned char>(buf[pos]) & 0xC0) == 0x80) return static_cast<size_t>(offset);
     return pos;
 }
 
@@ -2156,12 +2164,40 @@ static size_t clamp_caret_to_codepoint(const std::string& buf, ptrdiff_t offset)
 // A lead byte's declared width is only real if the declared-1 following
 // bytes are actual continuations (and not NUL). Otherwise this is a stray
 // lead byte and degrades to ONE unit, so the walker re-examines the next
-// byte as a fresh unit — byte-per-byte, as documented (greptile #83:
-// "\xC2\x41" with offset 1 must be 1, not 2).
+// byte as a fresh unit - byte-per-byte, as documented (greptile #83:
+// "\xC2\x41" with offset 1 must be 1, not 2). The decoded VALUE is also
+// validated: overlong encodings (2-byte < U+80, 3-byte < U+800, 4-byte
+// < U+10000), UTF-16 surrogates (U+D800..U+DFFF), and values above
+// U+10FFFF are malformed despite having continuation-shaped trailing
+// bytes, and degrade the same way (greptile follow-up: "\xED\xA0\x80"
+// with offset 1 must be 1, not 3).
 static int ValidatedSequenceLength(const unsigned char* p, int declared) {
     for (int i = 1; i < declared; ++i) {
         if ((p[i] & 0xC0) != 0x80) return 1; // not a continuation (covers NUL)
     }
+    // Decode the value for semantic validation.
+    unsigned long cp;
+    switch (declared) {
+    case 2:
+        cp = ((p[0] & 0x1FUL) << 6) | (p[1] & 0x3FUL);
+        break;
+    case 3:
+        cp = ((p[0] & 0x0FUL) << 12) | ((p[1] & 0x3FUL) << 6) | (p[2] & 0x3FUL);
+        break;
+    case 4:
+        cp = ((p[0] & 0x07UL) << 18) | ((p[1] & 0x3FUL) << 12) | ((p[2] & 0x3FUL) << 6) | (p[3] & 0x3FUL);
+        break;
+    default:
+        return 1;
+    }
+    // Overlong: the value could have been encoded shorter.
+    if (declared == 2 && cp < 0x80) return 1;
+    if (declared == 3 && cp < 0x800) return 1;
+    if (declared == 4 && cp < 0x10000) return 1;
+    // Surrogates are not valid codepoints in UTF-8.
+    if (cp >= 0xD800 && cp <= 0xDFFF) return 1;
+    // Above the Unicode range.
+    if (cp > 0x10FFFF) return 1;
     return declared;
 }
 

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -591,21 +591,35 @@ DASHER_API int dasher_get_offset(dasher_ctx* ctx);
 
 // ── Context awareness (RFC 0015) ──────────────────────────────────────────
 
+// Convert a platform caret position into the UTF-8 byte unit used by
+// dasher_set_offset / dasher_seed_buffer. utf16_offset counts UTF-16 code
+// units (Windows UIA / EDIT controls). A surrogate pair counts as two
+// units; an offset landing inside a pair resolves to the pair's start.
+// Malformed UTF-8 degrades byte-per-byte. Returns the byte offset; negative
+// and out-of-range values clamp to 0 / strlen. Returns -1 if text is NULL.
+DASHER_API int dasher_byte_offset_from_utf16(const char* utf8_text, int utf16_offset);
+
+// Codepoint-unit variant (macOS AX and GTK atspi report character counts;
+// emoji count as one here, two in UTF-16). Same clamping rules.
+DASHER_API int dasher_byte_offset_from_codepoints(const char* utf8_text, int codepoint_offset);
+
 // Re-anchor the model at a buffer position (v5's SetOffset). The language
 // model context becomes the edit buffer's text before the offset, so
 // predictions continue from there. Use after external edits moved the caret
 // within the session buffer. OFFSET IS A UTF-8 BYTE POSITION (the buffer's
-// unit throughout this CAPI) — frontends reading platform carets in
-// character/UTF-16 units must convert; a value that lands mid-codepoint
-// snaps down to the codepoint start rather than corrupting output.
+// unit throughout this CAPI) — convert platform carets with
+// dasher_byte_offset_from_utf16 / _from_codepoints; a value that lands
+// mid-codepoint snaps down to the codepoint start rather than corrupting
+// output.
 // Returns 0 on success, -1 on failure.
 DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset);
 
 // Replace the edit buffer with text read from the target field (e.g. via
 // UI Automation) and anchor the model at caret_offset — predictions then
 // continue from text the user did not type through Dasher (RFC 0015 tier 3).
-// caret_offset is a UTF-8 byte position (see dasher_set_offset for the unit
-// contract and mid-codepoint snapping). Emits output event 2 (buffer
+// caret_offset is a UTF-8 byte position — convert platform carets with
+// dasher_byte_offset_from_utf16 / _from_codepoints (see dasher_set_offset
+// for the full unit contract). Emits output event 2 (buffer
 // cleared) FIRST so subscribers resync their mirrors without injecting
 // (backspacing a whole field into the target would destroy the user's
 // text). Typing-rate stats reset. Realizes if needed.

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -589,6 +589,23 @@ DASHER_API int dasher_import_training_text(dasher_ctx* ctx, const char* text);
 // Returns -1 if the engine is not realized.
 DASHER_API int dasher_get_offset(dasher_ctx* ctx);
 
+// ── Context awareness (RFC 0015) ──────────────────────────────────────────
+
+// Re-anchor the model at a buffer position (v5's SetOffset). The language
+// model context becomes the edit buffer's text before the offset, so
+// predictions continue from there. Use after external edits moved the caret
+// within the session buffer. Returns 0 on success, -1 on failure.
+DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset);
+
+// Replace the edit buffer with text read from the target field (e.g. via
+// UI Automation) and anchor the model at caret_offset — predictions then
+// continue from text the user did not type through Dasher (RFC 0015 tier 3).
+// Emits output event 2 (buffer cleared) FIRST so subscribers resync their
+// mirrors without injecting (backspacing a whole field into the target would
+// destroy the user's text). Typing-rate stats reset. Realizes if needed.
+// Returns 0 on success, -1 on failure.
+DASHER_API int dasher_seed_buffer(dasher_ctx* ctx, const char* text, int caret_offset);
+
 // ── Typing rate (RFC 0012) ─────────────────────────────────────────────────
 //
 // Live typing-rate metrics from a rolling 5-second window of recent output.

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -594,15 +594,21 @@ DASHER_API int dasher_get_offset(dasher_ctx* ctx);
 // Re-anchor the model at a buffer position (v5's SetOffset). The language
 // model context becomes the edit buffer's text before the offset, so
 // predictions continue from there. Use after external edits moved the caret
-// within the session buffer. Returns 0 on success, -1 on failure.
+// within the session buffer. OFFSET IS A UTF-8 BYTE POSITION (the buffer's
+// unit throughout this CAPI) — frontends reading platform carets in
+// character/UTF-16 units must convert; a value that lands mid-codepoint
+// snaps down to the codepoint start rather than corrupting output.
+// Returns 0 on success, -1 on failure.
 DASHER_API int dasher_set_offset(dasher_ctx* ctx, int offset);
 
 // Replace the edit buffer with text read from the target field (e.g. via
 // UI Automation) and anchor the model at caret_offset — predictions then
 // continue from text the user did not type through Dasher (RFC 0015 tier 3).
-// Emits output event 2 (buffer cleared) FIRST so subscribers resync their
-// mirrors without injecting (backspacing a whole field into the target would
-// destroy the user's text). Typing-rate stats reset. Realizes if needed.
+// caret_offset is a UTF-8 byte position (see dasher_set_offset for the unit
+// contract and mid-codepoint snapping). Emits output event 2 (buffer
+// cleared) FIRST so subscribers resync their mirrors without injecting
+// (backspacing a whole field into the target would destroy the user's
+// text). Typing-rate stats reset. Realizes if needed.
 // Returns 0 on success, -1 on failure.
 DASHER_API int dasher_seed_buffer(dasher_ctx* ctx, const char* text, int caret_offset);
 

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -1066,3 +1066,44 @@ TEST(seed_buffer_realizes_lazy_engine) {
     (void)rc;
     dasher_destroy(ctx);
 }
+
+TEST(context_offsets_never_split_utf8_codepoints) {
+    // Greptile #83: platform carets arrive in character/UTF-16 units; a raw
+    // conversion to the buffer's UTF-8 bytes can land mid-sequence, which
+    // would corrupt every subsequent edit. Offsets that do land inside a
+    // multibyte sequence must snap DOWN to the codepoint start (the
+    // straddled character stays in the pre-caret context, never dropped).
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    // "héllo": é is U+00E9 = 2 UTF-8 bytes -> h(1) é(2) l l o = 6 bytes.
+    // Byte 2 is INSIDE é; both 2 and the trailing position must snap to 1
+    // (é's lead byte), keeping é before the caret.
+    ASSERT_EQ(dasher_seed_buffer(ctx, "h\xc3\xa9llo", 2), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 1);
+
+    // Same via set_offset within an existing buffer.
+    ASSERT_EQ(dasher_set_offset(ctx, 2), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 1);
+
+    // 3-byte sequence: "a" + U+4E2D (3 bytes) + "b" = 5 bytes total; the
+    // CJK char spans bytes 1-3. Offsets 2 and 3 snap to 1; offset 4 (the
+    // 'b') is a boundary and stays.
+    ASSERT_EQ(dasher_seed_buffer(ctx,
+                                 "a\xe4\xb8\xad"
+                                 "b",
+                                 3),
+              0);
+    ASSERT_EQ(dasher_get_offset(ctx), 1);
+    ASSERT_EQ(dasher_set_offset(ctx, 4), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 4);
+
+    // Boundary values pass through untouched: 0, and the full length.
+    ASSERT_EQ(dasher_set_offset(ctx, 0), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 0);
+    ASSERT_EQ(dasher_set_offset(ctx, 999), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 5);
+
+    dasher_destroy(ctx);
+}

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -1161,3 +1161,28 @@ TEST(caret_unit_conversion_translates_to_intended_byte_position) {
     ASSERT_EQ(dasher_get_offset(ctx), 4); // anchored at the true caret
     dasher_destroy(ctx);
 }
+
+TEST(caret_conversion_malformed_utf8_degrades_byte_per_byte) {
+    // Greptile #83 (comment 2): a stray lead byte must consume exactly ONE
+    // byte, never swallow the following byte as a phantom continuation -
+    // the documented contract, and what dasher_seed_buffer anchors on.
+    using conv16 = int (*)(const char*, int);
+    conv16 f16 = dasher_byte_offset_from_utf16;
+
+    // The reported case: 0xC2 claims 2 bytes but 0x41 is ASCII.
+    ASSERT_EQ(f16("\xc2\x41", 1), 1); // stray lead = one unit; 'A' is next
+
+    // Truncated lead at end of string: 0xC2 then NUL.
+    ASSERT_EQ(f16("\xc2", 1), 1);
+
+    // Truncated mid-sequence: 0xE0 0x80 (valid start) then NUL - the E0
+    // degrades to one stray, 0x80 is itself a stray continuation.
+    ASSERT_EQ(f16("\xe0\x80", 1), 1);
+    ASSERT_EQ(f16("\xe0\x80", 2), 2);
+
+    // Stray continuation bytes each count one unit.
+    ASSERT_EQ(f16("\x80\x80\x80", 2), 2);
+
+    // A VALID 2-byte sequence still converts exactly (regression guard).
+    ASSERT_EQ(f16("\xc2\xa9", 1), 2); // U+00A9 (c) = 2 bytes, 1 unit
+}

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -948,3 +948,121 @@ TEST(cps_reset_after_reset_settings) {
 
     dasher_destroy(ctx);
 }
+
+// ── Context awareness CAPI (RFC 0015) ─────────────────────────────────────
+
+TEST(seed_buffer_anchors_at_caret_and_replaces_output) {
+    // The direct-entry context tier: seed the edit buffer with the target
+    // field's text, anchor at the caret. Output text mirrors the seed (the
+    // message pane / get_output_text contract), offset equals the caret, and
+    // a buffer-clear event fired so subscribers resync without injecting.
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    int clear_events = 0;
+    dasher_set_output_callback(
+        ctx,
+        [](int event_type, const char* text, void* ud) {
+            if (event_type == 2) (*static_cast<int*>(ud))++;
+        },
+        &clear_events);
+
+    const char* seed = "Hello world";
+    ASSERT_EQ(dasher_seed_buffer(ctx, seed, 11), 0);
+    ASSERT_EQ(clear_events, 1);
+    ASSERT_STR_EQ(dasher_get_output_text(ctx), seed);
+    ASSERT_EQ(dasher_get_offset(ctx), 11);
+
+    // Caret beyond the buffer clamps to the end, not an error.
+    ASSERT_EQ(dasher_seed_buffer(ctx, "abc", 99), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 3);
+    ASSERT_EQ(clear_events, 2);
+
+    // Null text = empty buffer (field-context reset, v5 parity fallback).
+    ASSERT_EQ(dasher_seed_buffer(ctx, nullptr, 0), 0);
+    ASSERT_EQ(clear_events, 3);
+    ASSERT_STR_EQ(dasher_get_output_text(ctx), "");
+
+    // Negative caret clamps to 0.
+    ASSERT_EQ(dasher_seed_buffer(ctx, "xy", -5), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 0);
+
+    dasher_destroy(ctx);
+}
+
+TEST(seed_buffer_then_typing_appends_after_context) {
+    // After seeding mid-buffer, new engine output must APPEND at the caret,
+    // not replace the seed: the model root was built at the caret offset.
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    // Type a character via the engine: alphabet-stepping with the mouse held
+    // is how the restart-drift test drives output; reuse the same approach.
+    ASSERT_EQ(dasher_seed_buffer(ctx, "Hello ", 6), 0);
+
+    // Drive some zooming so the engine commits a symbol (deterministic
+    // trajectory: hold the mouse in the lower half to steer into the
+    // high-probability 't'-region after "Hello ").
+    dasher_mouse_down(ctx);
+    int64_t clock = 1000;
+    for (int i = 0; i < 200; i++) {
+        dasher_mouse_move(ctx, 640, 360);
+        dasher_frame(ctx, clock += 16, nullptr, nullptr, nullptr, nullptr);
+    }
+    dasher_mouse_up(ctx);
+
+    const char* out = dasher_get_output_text(ctx);
+    // Whatever was typed, it must sit AFTER the seeded context: prefix intact.
+    ASSERT(strncmp(out, "Hello ", 6) == 0);
+    ASSERT(strlen(out) >= 6);
+
+    dasher_destroy(ctx);
+}
+
+TEST(set_offset_reanchors_within_buffer) {
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    ASSERT_EQ(dasher_seed_buffer(ctx, "abcdef", 6), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 6);
+
+    // Re-anchor mid-buffer (v5 tap-to-position parity).
+    ASSERT_EQ(dasher_set_offset(ctx, 3), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 3);
+
+    // Out-of-range clamps to the end; negative is rejected.
+    ASSERT_EQ(dasher_set_offset(ctx, 999), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 6);
+    ASSERT_EQ(dasher_set_offset(ctx, -1), -1);
+
+    // Re-anchoring does NOT fire a buffer-clear (the buffer did not change —
+    // subscribers must not resync).
+    int clear_events = 0;
+    dasher_set_output_callback(
+        ctx,
+        [](int event_type, const char*, void* ud) {
+            if (event_type == 2) (*static_cast<int*>(ud))++;
+        },
+        &clear_events);
+    ASSERT_EQ(dasher_set_offset(ctx, 2), 0);
+    ASSERT_EQ(clear_events, 0);
+
+    dasher_destroy(ctx);
+}
+
+TEST(seed_buffer_realizes_lazy_engine) {
+    // A direct-entry frontend reads the target field BEFORE the first frame;
+    // seeding must realize on demand rather than fail (mirrors set_palette).
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    // NOTE: no dasher_set_screen_size — unrealized engine.
+    // Screen size is what triggers realize in this CAPI; seeding without it
+    // must still succeed or cleanly fail — but never crash.
+    int rc = dasher_seed_buffer(ctx, "x", 1);
+    ASSERT(rc == 0 || rc == -1);
+    (void)rc;
+    dasher_destroy(ctx);
+}

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -1186,3 +1186,56 @@ TEST(caret_conversion_malformed_utf8_degrades_byte_per_byte) {
     // A VALID 2-byte sequence still converts exactly (regression guard).
     ASSERT_EQ(f16("\xc2\xa9", 1), 2); // U+00A9 (c) = 2 bytes, 1 unit
 }
+
+TEST(caret_conversion_rejects_semantically_invalid_utf8) {
+    // Greptile #83 follow-up: continuation-shaped trailing bytes are not
+    // enough - the decoded VALUE must be a valid scalar. Overlongs,
+    // surrogates, and above-U+10FFFF degrade byte-per-byte.
+    using conv16 = int (*)(const char*, int);
+    conv16 f16 = dasher_byte_offset_from_utf16;
+
+    // ED A0 80 = U+D800 (surrogate) - 3 continuation-shaped bytes, but
+    // surrogates are invalid in UTF-8. Degrades to 3 strays.
+    ASSERT_EQ(f16("\xed\xa0\x80", 1), 1); // was 3 pre-fix
+    ASSERT_EQ(f16("\xed\xa0\x80", 3), 3);
+
+    // C0 80 = overlong NUL (2-byte encoding of value < 0x80).
+    ASSERT_EQ(f16("\xc0\x80", 1), 1); // was 2
+
+    // E0 80 80 = overlong NUL (3-byte encoding of value < 0x800).
+    ASSERT_EQ(f16("\xe0\x80\x80", 1), 1); // was 3
+
+    // F4 90 80 80 = U+110000 (above Unicode range).
+    ASSERT_EQ(f16("\xf4\x90\x80\x80", 1), 1); // was 4
+
+    // Valid boundary values still work: F0 9F 98 80 = U+1F600 (emoji).
+    ASSERT_EQ(f16("\xf0\x9f\x98\x80", 2), 4); // 2 UTF-16 units
+
+    // C2 A9 = U+00A9 - the minimum valid 2-byte value.
+    ASSERT_EQ(f16("\xc2\xa9", 1), 2);
+
+    // E0 A0 80 = U+0800 - the minimum valid 3-byte value.
+    ASSERT_EQ(f16("\xe0\xa0\x80", 1), 3);
+}
+
+TEST(clamp_caret_survives_long_stray_continuation_runs) {
+    // Greptile #83 follow-up: the 3-step backward scan can land on another
+    // continuation byte when 4+ strays run together; a correctly converted
+    // boundary must not be moved. Use set_offset (which clamps) with a
+    // buffer of 5 stray continuations + valid text.
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+
+    // 5 stray continuation bytes + "AB"
+    // Bytes: 80 80 80 80 80 41 42 (indices 0-6)
+    // A caret at byte 3 (still mid-stray-run) should stay at 3.
+    ASSERT_EQ(dasher_seed_buffer(ctx,
+                                 "\x80\x80\x80\x80\x80"
+                                 "AB",
+                                 3),
+              0);
+    ASSERT_EQ(dasher_get_offset(ctx), 3); // not snapped to 0 (still stray)
+
+    dasher_destroy(ctx);
+}

--- a/tests/test_capi_extended.cpp
+++ b/tests/test_capi_extended.cpp
@@ -1107,3 +1107,57 @@ TEST(context_offsets_never_split_utf8_codepoints) {
 
     dasher_destroy(ctx);
 }
+
+TEST(caret_unit_conversion_translates_to_intended_byte_position) {
+    // Greptile #83 follow-up: snapping prevents corruption but is not
+    // conversion — a UTF-16 count is numerically wrong as a byte offset
+    // (CJK: UTF-16 10 vs byte 30). These helpers are THE conversion path
+    // from platform caret units to the buffer unit.
+    using conv16 = int (*)(const char*, int);
+    using convcp = int (*)(const char*, int);
+    conv16 f16 = dasher_byte_offset_from_utf16;
+    convcp fcp = dasher_byte_offset_from_codepoints;
+
+    // ASCII: all three units coincide.
+    ASSERT_EQ(f16("hello", 3), 3);
+    ASSERT_EQ(fcp("hello", 3), 3);
+
+    // 2-byte e-acute: UTF-8 "h\xC3\xA9llo" is 6 bytes; units: h,e,l,l,o = 5.
+    ASSERT_EQ(f16("h\xc3\xa9llo", 2), 3); // after 'e' (2 units) = byte 3
+    ASSERT_EQ(fcp("h\xc3\xa9llo", 2), 3);
+    ASSERT_EQ(f16("h\xc3\xa9llo", 1), 1); // after 'h' = byte 1
+
+    // 3-byte CJK: UTF-8 "\xE4\xB8\xAD" = 3 bytes, 1 unit in both systems.
+    ASSERT_EQ(f16("\xe4\xb8\xad\xe4\xb8\xad", 2), 6); // two chars = 6 bytes
+    ASSERT_EQ(fcp("\xe4\xb8\xad\xe4\xb8\xad", 2), 6);
+    ASSERT_EQ(f16("\xe4\xb8\xad\xe4\xb8\xad", 1), 3);
+
+    // 4-byte emoji U+1F600: 4 bytes, 1 codepoint but 2 UTF-16 units.
+    const char* emoji = "\xf0\x9f\x98\x80"; // 😀
+    ASSERT_EQ(f16(emoji, 2), 4);            // after the pair = byte 4
+    ASSERT_EQ(f16(emoji, 1), 0);            // MID-PAIR resolves to the pair start
+    ASSERT_EQ(fcp(emoji, 1), 4);            // codepoints: emoji is one = byte 4
+
+    // Mixed "a😀b" (bytes 0..5): units16 = a(1) + emoji(2) + b(1) = 4.
+    const char* mixed = "a\xf0\x9f\x98\x80"
+                        "b";
+    ASSERT_EQ(f16(mixed, 1), 1); // after 'a'
+    ASSERT_EQ(f16(mixed, 2), 1); // mid-pair -> pair start = after 'a'
+    ASSERT_EQ(f16(mixed, 3), 5); // after emoji (before 'b')
+    ASSERT_EQ(f16(mixed, 4), 6); // after 'b' = end
+    ASSERT_EQ(fcp(mixed, 2), 5); // after a + emoji (2 codepoints)
+
+    // Clamping.
+    ASSERT_EQ(f16("abc", 99), 3);
+    ASSERT_EQ(f16("abc", -1), 0);
+    ASSERT_EQ(fcp("", 0), 0);
+    ASSERT_EQ(f16(nullptr, 3), -1); // null text is an error
+
+    // The full pipeline: UIA caret in UTF-16 units -> byte offset -> seed.
+    dasher_ctx* ctx = create_isolated_context();
+    ASSERT(ctx != nullptr);
+    dasher_set_screen_size(ctx, 800, 600);
+    ASSERT_EQ(dasher_seed_buffer(ctx, emoji, f16(emoji, 2)), 0);
+    ASSERT_EQ(dasher_get_offset(ctx), 4); // anchored at the true caret
+    dasher_destroy(ctx);
+}


### PR DESCRIPTION
## Summary

Implements the engine side of RFC 0015's context-awareness amendment (governance PR #37, research in Dasher-Windows #50): two new CAPI functions that let direct-entry frontends re-anchor and seed the language model from the target field.

### `dasher_set_offset(ctx, offset)`
Re-anchor the model at a buffer position — v5's `SetOffset` at the CAPI boundary (previously only `dasher_get_offset` was exported). The LM context becomes the buffer text before the offset, so predictions continue mid-text. Clamps out-of-range to the end, rejects negatives, fires **no** buffer-clear (the buffer didn't change).

### `dasher_seed_buffer(ctx, text, caret_offset)`
Replace the edit buffer with text the frontend read from the target field (UIA on Windows, AX on macOS, atspi on GTK) and anchor at the caret — predictions then continue from **pre-existing** text the user didn't type through Dasher (v5 never had this on Windows).

- Emits output **event 2 (buffer cleared) first**, so subscribers resync mirrors without injecting — backspacing a whole field into the target would destroy the user's text (the same reasoning as Dasher-Windows #45's event-2 contract)
- Rate stats reset (seeded context isn't this session's typing)
- Realizes on demand (direct-entry frontends read the field before the first frame), mirroring `dasher_set_palette`

### Context chain (verified)
`dasher_seed_buffer`/`dasher_set_offset` → `SetOffset` → `GetRoot(bEnteredLast=true, offset)` → `GetContextSymbols` → the CAPI `Interface::GetContext` reads `ctx->editBuffer` → the LM is seeded from the text before the caret, root node marked `NF_SEEN|NF_COMMITTED` (never re-committed as output).

## Tests (4 new, `test_capi_extended.cpp`)
- `seed_buffer_anchors_at_caret_and_replaces_output` — output mirrors the seed, offset = caret, clear-event fires; caret clamping; null text = empty-buffer reset; negative caret clamps to 0
- `seed_buffer_then_typing_appends_after_context` — after seeding `"Hello "` mid-buffer, engine output lands **after** the seeded prefix (prefix-intact assertion)
- `set_offset_reanchors_within_buffer` — re-anchor, clamp, negative rejection, and **no** clear-event on pure re-anchor
- `seed_buffer_realizes_lazy_engine` — seeding an unrealized engine never crashes

Full engine matrix: 40/40 suites green.

## Type of change
- [x] New feature (CAPI)

## Definition of Done
- [x] Tests green (27/27 extended suite, 40/40 matrix)
- [x] clang-format clean
- [x] DCO signed














<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds context-aware buffer seeding and model re-anchoring to the C API, together with explicit platform-caret conversion helpers.
- Adds UTF-16/codepoint-to-UTF-8-byte offset conversion with malformed-input handling.
- Adds APIs to seed the edit buffer and re-anchor its language-model context.
- Adds coverage for lazy realization, offset clamping, Unicode conversion, and malformed UTF-8.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/CAPI.cpp | Implements context realization, validated caret conversion, boundary clamping, buffer seeding, and model re-anchoring; the previously reported Unicode boundary failures are addressed. |
| src/dasher.h | Exposes the new context APIs and documents their UTF-8 byte-offset, malformed-input, clamping, and event contracts. |
| tests/test_capi_extended.cpp | Adds focused coverage for context seeding, re-anchoring, lazy realization, Unicode caret conversion, malformed UTF-8, and continuation-byte boundaries. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant F as Frontend
    participant C as C API
    participant B as Edit Buffer
    participant M as Dasher Model
    F->>C: Convert platform caret to UTF-8 byte offset
    C-->>F: Byte offset
    F->>C: dasher_seed_buffer(text, offset)
    C->>B: Replace text and set cursor
    C-->>F: Buffer-cleared event
    C->>M: SetOffset(clamped offset)
    M->>B: Read context before caret
    M-->>F: Predictions continue from seeded context
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(capi): clamp validates the candidate..."](https://github.com/dasher-project/dashercore/commit/fbc8940d6b10540163a28cb3749baa9f26122293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61044474)</sub>

<!-- /greptile_comment -->