### PR TITLE
fix(core): startup training load scans the per-context user dir (#84)

### DIFF
--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -651,6 +651,17 @@ Resets every parameter to its built-in default value (from `Parameters.h`). It r
 
 This only affects the **in-memory** session — it does not delete the persisted files. Frontends that want persisted defaults should delete `dasher_settings.xml` (and `appearance_settings.xml` for the RFC 0007 appearance sidecar) from the user directory before calling, so defaults also load on the next launch. Null-safe: a no-op for `NULL ctx`.
 
+### Training data
+
+```c
+const char* dasher_get_training_path(dasher_ctx* ctx);   // absolute path, engine-owned
+int dasher_import_training_text(dasher_ctx* ctx, const char* text);
+int dasher_capi_version(void);                           // 1 = user-dir training scan
+```
+
+- `dasher_get_training_path` — the single file adaptive learning appends to for the current alphabet (`<user_dir>/training_<alphabet>.txt` at the user-dir **root**). Frontend training UIs (export / size / reset) must read this path, never a derived one. Empty when no model is realized. Pointer valid until the next API call on the context.
+- Since CAPI version 1, the startup training load scans the per-context **user data directory** (in addition to the bundled data dir) — learning accumulated in previous sessions is loaded automatically for split-dir frontends (Android, GTK, Apple). Single-dir setups (`data_dir == user_dir`, Windows today) are scanned once, never double-trained. Frontends that previously re-imported the training file after `dasher_create` as a stopgap **must** gate that on `dasher_capi_version() >= 1` being false, or the same text will be counted twice.
+
 ## Frontend Integration Examples
 
 ### Swift (iOS)

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -909,6 +909,9 @@ DASHER_API dasher_ctx* dasher_create(const char* data_dir, const char* user_dir,
         // created later (the FileUtils globals are process-wide,
         // last-create-wins — see CDasherInterfaceBase::WriteTrainFile).
         ctx->intf->SetUserDataDirectory(writableDir);
+        // Per-context data dir, same rationale: the startup training scan
+        // reads THIS context's bundled corpus, not the global's (#84).
+        ctx->intf->SetDataDirectory(dir);
     } catch (const std::exception& e) {
         s_errorString = std::string("Failed to create Dasher session: ") + e.what();
         if (out_error) *out_error = s_errorString.data();
@@ -2139,6 +2142,10 @@ DASHER_API const char* dasher_get_training_path(dasher_ctx* ctx) {
         ctx->tlString.clear();
     }
     return ctx->tlString.c_str();
+}
+
+DASHER_API int dasher_capi_version(void) {
+    return DASHER_CAPI_VERSION;
 }
 
 DASHER_API int dasher_get_offset(dasher_ctx* ctx) {

--- a/src/DasherCore/DasherInterfaceBase.h
+++ b/src/DasherCore/DasherInterfaceBase.h
@@ -378,6 +378,13 @@ class Dasher::CDasherInterfaceBase : public CMessageDisplay, private NoClones {
     void SetUserDataDirectory(const std::string& dir) { m_userDataDir = dir; }
     const std::string& GetUserDataDirectory() const { return m_userDataDir; }
 
+    /// Per-context bundled data directory (read-only corpora), same
+    /// last-created-context rationale as SetUserDataDirectory: the startup
+    /// training scan must read THIS context's data dir, not the global.
+    /// Empty = fall back to the global (legacy single-context embedders).
+    void SetDataDirectory(const std::string& dir) { m_dataDir = dir; }
+    const std::string& GetDataDirectory() const { return m_dataDir; }
+
     /// Relative filename of the current alphabet's user training file (e.g.
     /// "training_english_GB.txt"), or "" when no model is realized or the
     /// alphabet declares no training file. Callers resolve it against THEIR
@@ -511,6 +518,9 @@ class Dasher::CDasherInterfaceBase : public CMessageDisplay, private NoClones {
 
     /// Per-context user dir — see SetUserDataDirectory.
     std::string m_userDataDir;
+
+    /// Per-context bundled data dir — see SetDataDirectory.
+    std::string m_dataDir;
 
     void ChangeAlphabet();
     void ChangeColors();

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -56,18 +56,29 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
         return;
     }
 
+    ScanDirectory(parser, strPattern, s_dataDirectory);
+}
+
+void Dasher::FileUtils::ScanDirectory(AbstractParser* parser, const std::string& strPattern, const std::string& dir) {
+    // Same absolute-path contract as ScanFiles: one specific file, no glob.
+    std::error_code error_code;
+    std::filesystem::path p(strPattern);
+    if (p.is_absolute()) {
+        if (std::filesystem::exists(p, error_code) && std::filesystem::is_regular_file(p, error_code)) {
+            parser->ParseFile(strPattern, IsFileWriteable(strPattern));
+        }
+        return;
+    }
+
     // Replace * with .* for actual regex matching
     // Note: pattern is interpreted as regex, so "alphabet.*.xml" matches "alphabet.English.xml"
     const std::regex pattern = std::regex(strPattern);
 
-    // Search ONLY in the specified data directory. The old fallback to
-    // current_path() turned an empty/missing data dir (frontend passed a bad
-    // bundle path) into an unbounded scan of the user's home directory —
-    // minutes of regex per file while the caller held its engine lock
-    // (watch spike hang, 2026-08-31). No data dir means nothing to scan.
+    // Search ONLY in the specified directory; empty means nothing to scan
+    // (same rationale as ScanFiles — never fall back to current_path()).
     std::vector<std::filesystem::path> search_paths;
-    if (!s_dataDirectory.empty()) {
-        search_paths.push_back(std::filesystem::path(s_dataDirectory));
+    if (!dir.empty()) {
+        search_paths.push_back(std::filesystem::path(dir));
     }
 
     for (const std::filesystem::path& current_path : search_paths) {
@@ -129,6 +140,27 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
             }
         }
     }
+}
+
+bool Dasher::FileUtils::IsSameDirectory(const std::string& a, const std::string& b) {
+    if (a.empty() || b.empty()) return false;
+    std::error_code ec;
+    std::filesystem::path pa(a), pb(b);
+    if (std::filesystem::exists(pa, ec) && !ec && std::filesystem::exists(pb, ec) && !ec) {
+        // Resolves symlinks / junctions and (on Windows) case-insensitivity.
+        ec.clear();
+        bool eq = std::filesystem::equivalent(pa, pb, ec);
+        if (!ec) return eq;
+        // exists() said yes but equivalent() failed (e.g. permission on a
+        // parent) — fall through to the lexical comparison below.
+    }
+    ec.clear();
+    const auto na = std::filesystem::weakly_canonical(pa, ec);
+    if (ec) return false;
+    ec.clear();
+    const auto nb = std::filesystem::weakly_canonical(pb, ec);
+    if (ec) return false;
+    return na == nb;
 }
 
 bool Dasher::FileUtils::WriteUserDataFile(const std::string& filename, const std::string& strNewText, bool append) {

--- a/src/DasherCore/FileUtils.h
+++ b/src/DasherCore/FileUtils.h
@@ -24,6 +24,19 @@ class FileUtils {
     // Open File with the filename strPattern in the project directory
     static void ScanFiles(AbstractParser* parser, const std::string& strPattern);
 
+    // Scan a specific directory (recursively) instead of the process-global
+    // data directory. Same pattern semantics as ScanFiles; an empty dir
+    // scans nothing. Lets per-context callers (NodeCreationManager training
+    // load, dasher-project/DasherCore#84) avoid the last-created-context
+    // globals that ScanFiles consults.
+    static void ScanDirectory(AbstractParser* parser, const std::string& strPattern, const std::string& dir);
+
+    // True when two directory paths name the same location: uses
+    // std::filesystem::equivalent when both exist (symlinks, junctions,
+    // case-insensitive roots), falling back to weakly_canonical lexical
+    // comparison for not-yet-created dirs. Empty paths never match.
+    static bool IsSameDirectory(const std::string& a, const std::string& b);
+
     // Writes into the user file
     static bool WriteUserDataFile(const std::string& filename, const std::string& strNewText, bool append);
 

--- a/src/DasherCore/NodeCreationManager.cpp
+++ b/src/DasherCore/NodeCreationManager.cpp
@@ -98,7 +98,25 @@ CNodeCreationManager::CNodeCreationManager(CSettingsStore* pSettingsStore, CDash
 
     if (!pAlphInfo->GetTrainingFile().empty()) {
         ProgressNotifier pn(pInterface, m_pTrainer);
-        Dasher::FileUtils::ScanFiles(&pn, pAlphInfo->GetTrainingFile());
+        // Per-context dirs (#84): train from the bundled corpus in THIS
+        // context's data dir, then from the user's accumulated training in
+        // THIS context's user dir. Adaptive appends land in the user dir
+        // (ResolveUserDataPath), so skipping it silently discarded all
+        // learning from previous sessions on every frontend that separates
+        // the two dirs (Android, GTK, Apple) — only Windows survived, by
+        // passing one dir for both. User-dir scan runs LAST so the
+        // ProgressNotifier's user/system flags describe the newest file
+        // (they reset per Parse) and the "may not be learning" hint stays
+        // accurate. Skipped entirely when the dirs are one and the same, so
+        // single-dir setups never double-train.
+        const std::string& dataDir = pInterface->GetDataDirectory();
+        const std::string& userDir = pInterface->GetUserDataDirectory();
+        if (!dataDir.empty())
+            Dasher::FileUtils::ScanDirectory(&pn, pAlphInfo->GetTrainingFile(), dataDir);
+        else
+            Dasher::FileUtils::ScanFiles(&pn, pAlphInfo->GetTrainingFile()); // legacy: global data dir
+        if (!userDir.empty() && !Dasher::FileUtils::IsSameDirectory(userDir, dataDir))
+            Dasher::FileUtils::ScanDirectory(&pn, pAlphInfo->GetTrainingFile(), userDir);
         if (!pn.has_parsed_from_user_dir()) {
             /// TRANSLATORS: These 3 messages will be displayed when the user has just chosen a new alphabet. The %s
             /// parameter will be the name of the alphabet.

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -593,6 +593,19 @@ DASHER_API int dasher_import_training_text(dasher_ctx* ctx, const char* text);
 // dasher-project/Dasher-Windows#53).
 DASHER_API const char* dasher_get_training_path(dasher_ctx* ctx);
 
+// C API version, incremented when a behavioural change frontends might
+// condition on lands. Frontends should gate compatibility workarounds on
+// this rather than probing for symbols.
+//
+//   1 — startup training load scans the per-context USER data directory in
+//       addition to the bundled data dir, so split-dir frontends (Android,
+//       GTK, Apple) finally load learning accumulated in previous sessions
+//       (DasherCore#84). A frontend that re-imports the training file after
+//       create as a stopgap MUST skip that re-import at version >= 1 or the
+//       text would be counted twice.
+DASHER_API int dasher_capi_version(void);
+#define DASHER_CAPI_VERSION 1
+
 // Get the current Dasher offset (character position in the output).
 // Returns -1 if the engine is not realized.
 DASHER_API int dasher_get_offset(dasher_ctx* ctx);

--- a/tests/test_training.cpp
+++ b/tests/test_training.cpp
@@ -1,5 +1,7 @@
 // Training adaptation tests: verify training text changes model behavior
 #include "test_common.h"
+#include <fstream>
+
 static unsigned long hash_probabilities(dasher_ctx* ctx) {
     int lbnds[256], hbnds[256];
     int n = dasher_get_probabilities(ctx, lbnds, hbnds, 256);
@@ -10,6 +12,98 @@ static unsigned long hash_probabilities(dasher_ctx* ctx) {
         h = ((h << 5) + h) + hbnds[i];
     }
     return h;
+}
+
+// Writes a distinctive corpus as the engine would have accumulated it (the
+// user-dir ROOT is where ResolveUserDataPath appends).
+static void write_user_training(const ScopedTempDir& dir, const char* text, int repeat) {
+    std::ofstream out(std::filesystem::path(dir.path) / "training_english_GB.txt", std::ios::app);
+    for (int i = 0; i < repeat; i++)
+        out << text;
+}
+
+TEST(capi_version_reports_user_dir_scan) {
+    // Version 1 = startup training load includes the per-context user dir
+    // (DasherCore#84). Frontends gate their stopgap re-import on this.
+    printf("  capi version: %d\n", dasher_capi_version());
+    ASSERT(dasher_capi_version() >= 1);
+}
+
+TEST(training_user_dir_loaded_at_startup) {
+    // Baseline: fresh user dir, nothing accumulated.
+    unsigned long baseline;
+    {
+        ScopedContext ctx(800, 600);
+        run_frames(ctx, 3);
+        baseline = hash_probabilities(ctx);
+    }
+    ASSERT(baseline != 0);
+
+    // Same data dir; user dir pre-populated with accumulated training in the
+    // location the engine itself appends to. The startup scan must load it —
+    // before #84 the scan walked the data dir only and split-dir frontends
+    // lost all learning between sessions.
+    ScopedTempDir userDir;
+    write_user_training(userDir, "xyzzy quork zumble flibbertigibbet zatch ", 60);
+
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, userDir.c_str(), nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    run_frames(ctx, 3);
+    unsigned long trained = hash_probabilities(ctx);
+    dasher_destroy(ctx);
+
+    printf("  baseline=%lu trained=%lu\n", baseline, trained);
+    ASSERT(trained != 0);
+    ASSERT(trained != baseline);
+}
+
+TEST(training_scan_is_per_context) {
+    // Context A has accumulated training; context B is created AFTER A, so
+    // the process-global FileUtils dirs belong to A. B (fresh user dir) must
+    // match the no-training baseline — its scan reads interface-owned dirs,
+    // not the globals (DasherCore#84 / last-create-wins wrinkle).
+    unsigned long baseline;
+    {
+        ScopedContext ctx(800, 600);
+        run_frames(ctx, 3);
+        baseline = hash_probabilities(ctx);
+    }
+    ASSERT(baseline != 0);
+
+    ScopedTempDir dirA;
+    write_user_training(dirA, "asymmetric corpus unique to context a brangler ", 60);
+    dasher_ctx* a = dasher_create(TEST_DATA_DIR, dirA.c_str(), nullptr);
+    ASSERT(a);
+    dasher_set_screen_size(a, 800, 600);
+    run_frames(a, 3);
+
+    ScopedContext b(800, 600); // created after A — globals point at A's dirs
+    run_frames(b, 3);
+    unsigned long hashB = hash_probabilities(b);
+
+    dasher_destroy(a);
+
+    printf("  baseline=%lu b=%lu\n", baseline, hashB);
+    ASSERT_EQ(hashB, baseline);
+}
+
+TEST(training_same_dir_setup_remains_valid) {
+    // Windows-style single-dir setup (data dir == user dir): the user-dir
+    // scan is skipped so nothing double-trains; engine realizes normally
+    // and probabilities stay normalized.
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, TEST_DATA_DIR, nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    run_frames(ctx, 3);
+
+    int lbnds[256], hbnds[256];
+    int n = dasher_get_probabilities(ctx, lbnds, hbnds, 256);
+    ASSERT(n > 0);
+    ASSERT_EQ(hbnds[n - 1], 65536);
+
+    dasher_destroy(ctx);
+    printf("  single-dir setup: %d children, normalized OK\n", n);
 }
 
 TEST(training_import_returns_success) {


### PR DESCRIPTION
Closes #84.

## What

- **`FileUtils::ScanDirectory(parser, pattern, dir)`** — the directory walk extracted from `ScanFiles`, aimed at an explicit directory instead of the process-global data dir. `ScanFiles` behaviour unchanged for existing callers.
- **`FileUtils::IsSameDirectory`** — `equivalent()`-based (symlinks/junctions/case) with a `weakly_canonical` lexical fallback for not-yet-created dirs.
- **Per-context data dir** on `CDasherInterfaceBase` (`SetDataDirectory`/`GetDataDirectory`), beside the per-context user dir #85 added — the training scan previously consulted the last-create-wins globals, so a context created after another could scan the wrong corpus. `CNodeCreationManager` now trains from *this* context's data dir, then its user dir **when distinct** (single-dir setups like Windows scan once — never double-trained). User scan runs last so the ProgressNotifier's user/system flags (reset per Parse) describe the newest file and the "may not be learning" hint stays accurate.
- **`dasher_capi_version()` → 1** — frontends running a stopgap post-create re-import of the training file must skip it at version ≥ 1 or the same text is counted twice. Documented in `dasher.h` + `docs/C_API.md`.

## Why

#84: adaptive appends land in `<user_dir>/training_<alphabet>.txt` but the startup scan walked the data dir only. Android, GTK and Apple silently discarded **all** learning between sessions; Windows survived only because it passes one directory as both `data_dir` and `user_dir`. With this, split-dir frontends load accumulated learning automatically — and the Apple-side suppression of the "No user training text found" message (`DasherViewModel.swift:59`) can eventually be lifted.

## Tests (`dasher_training_tests`, 10/10; full matrix 43/43)

- `capi_version_reports_user_dir_scan` — version ≥ 1
- `training_user_dir_loaded_at_startup` — a training file in the user-dir root (where the engine itself appends) shifts model probabilities vs. the clean baseline
- `training_scan_is_per_context` — context B created *after* a trained context A matches the clean baseline despite the globals pointing at A's dirs
- `training_same_dir_setup_remains_valid` — `data_dir == user_dir` realizes and stays normalized (no double scan)

## Follow-ups (frontend repos, in flight)

- Dasher-Android #37 / Dasher-GTK #83: bump the submodule past this, bind `dasher_get_training_path`, version-gate any stopgap re-import, rebind training UI to the engine path.

DCO signed.



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61819698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/dasher-project/-/pull-requests/dasher-project/dashercore/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

<details><summary><h3>Summary</h3></summary>

- Extracts explicit-directory scanning and adds filesystem-aware directory identity checks.
- Stores bundled and user directories on each interface context and uses them during training initialization.
- Adds a C API capability version and documents the frontend compatibility requirement.
- Adds regression coverage for split-directory, multi-context, and single-directory setups.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host
    participant CAPI
    participant Interface
    participant Training
    Host->>CAPI: dasher_create(dataDir, userDir)
    CAPI->>Interface: SetDataDirectory(dataDir)
    CAPI->>Interface: SetUserDataDirectory(userDir)
    Host->>CAPI: dasher_set_screen_size(...)
    CAPI->>Interface: Realize()
    Interface->>Training: Scan bundled data directory
    alt User directory is distinct
        Interface->>Training: Scan user directory last
    end
```
</details>

<!-- /greptile_comment -->