### PR TITLE
fix: the emergency 'Default' alphabet was selectable and dead (#88)

### DIFF
--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -651,6 +651,17 @@ Resets every parameter to its built-in default value (from `Parameters.h`). It r
 
 This only affects the **in-memory** session — it does not delete the persisted files. Frontends that want persisted defaults should delete `dasher_settings.xml` (and `appearance_settings.xml` for the RFC 0007 appearance sidecar) from the user directory before calling, so defaults also load on the next launch. Null-safe: a no-op for `NULL ctx`.
 
+### Training data
+
+```c
+const char* dasher_get_training_path(dasher_ctx* ctx);   // absolute path, engine-owned
+int dasher_import_training_text(dasher_ctx* ctx, const char* text);
+int dasher_capi_version(void);                           // 1 = user-dir training scan
+```
+
+- `dasher_get_training_path` — the single file adaptive learning appends to for the current alphabet (`<user_dir>/training_<alphabet>.txt` at the user-dir **root**). Frontend training UIs (export / size / reset) must read this path, never a derived one. Empty when no model is realized. Pointer valid until the next API call on the context.
+- Since CAPI version 1, the startup training load scans the per-context **user data directory** (in addition to the bundled data dir) — learning accumulated in previous sessions is loaded automatically for split-dir frontends (Android, GTK, Apple). Single-dir setups (`data_dir == user_dir`, Windows today) are scanned once, never double-trained. Frontends that previously re-imported the training file after `dasher_create` as a stopgap **must** gate that on `dasher_capi_version() >= 1` being false, or the same text will be counted twice.
+
 ## Frontend Integration Examples
 
 ### Swift (iOS)

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -909,6 +909,9 @@ DASHER_API dasher_ctx* dasher_create(const char* data_dir, const char* user_dir,
         // created later (the FileUtils globals are process-wide,
         // last-create-wins — see CDasherInterfaceBase::WriteTrainFile).
         ctx->intf->SetUserDataDirectory(writableDir);
+        // Per-context data dir, same rationale: the startup training scan
+        // reads THIS context's bundled corpus, not the global's (#84).
+        ctx->intf->SetDataDirectory(dir);
     } catch (const std::exception& e) {
         s_errorString = std::string("Failed to create Dasher session: ") + e.what();
         if (out_error) *out_error = s_errorString.data();
@@ -2139,6 +2142,10 @@ DASHER_API const char* dasher_get_training_path(dasher_ctx* ctx) {
         ctx->tlString.clear();
     }
     return ctx->tlString.c_str();
+}
+
+DASHER_API int dasher_capi_version(void) {
+    return DASHER_CAPI_VERSION;
 }
 
 DASHER_API int dasher_get_offset(dasher_ctx* ctx) {

--- a/src/DasherCore/Alphabet/AlphIO.cpp
+++ b/src/DasherCore/Alphabet/AlphIO.cpp
@@ -357,9 +357,12 @@ std::string CAlphIO::FileNameFor(const std::string& AlphID) const {
     return it == AlphabetFiles.end() ? std::string() : it->second;
 }
 
-void CAlphIO::ScanNameIndex() {
+void CAlphIO::ScanNameIndex(const std::string& dir) {
     AlphabetIndexer indexer(this);
-    Dasher::FileUtils::ScanFiles(&indexer, "alphabet.*.xml");
+    if (!dir.empty())
+        Dasher::FileUtils::ScanDirectory(&indexer, "alphabet.*.xml", dir);
+    else
+        Dasher::FileUtils::ScanFiles(&indexer, "alphabet.*.xml");
 }
 
 bool CAlphIO::LoadAlphabetFile(const std::string& filename) {

--- a/src/DasherCore/Alphabet/AlphIO.cpp
+++ b/src/DasherCore/Alphabet/AlphIO.cpp
@@ -109,7 +109,14 @@ class AlphabetIndexer : public AbstractParser {
 using namespace Dasher;
 
 CAlphIO::CAlphIO(CMessageDisplay* pMsgs) : AbstractXMLParser(pMsgs) {
-    Alphabets["Default"] = CreateDefault();
+    // The bare a-z "Default" emergency alphabet is NO LONGER registered
+    // eagerly. Registered, it was selectable in pickers and persistable in
+    // settings — and it is structurally dead (no space, no newline, no
+    // groups): an engine loaded with it renders, reports no error, and
+    // commits no output however long you drive (reported as "no text goes
+    // into the output area"). GetInfo now falls back to the preferred real
+    // alphabet, and fabricates the emergency one only when nothing at all
+    // loaded — the last-ditch case it was written for.
 }
 
 SGroupInfo* CAlphIO::ParseGroupRecursive(pugi::xml_node& group_node, CAlphInfo* CurrentAlphabet,
@@ -372,9 +379,22 @@ std::string CAlphIO::GetDefault() const {
 
 const CAlphInfo* CAlphIO::GetInfo(const std::string& AlphabetID) const {
     auto it = Alphabets.find(AlphabetID);
-    if (it == Alphabets.end())             // if we don't have the alphabet they ask for,
-        it = Alphabets.find(GetDefault()); // give them default - it's better than nothing
-    return it->second;
+    if (it == Alphabets.end()) {
+        // Unknown (or the retired emergency "Default") id: fall back to the
+        // preferred real alphabet — silently, so pickers and saved settings
+        // self-heal on load.
+        it = Alphabets.find("English with limited punctuation");
+        if (it == Alphabets.end() && !Alphabets.empty()) {
+            // Preferred default missing (custom data dir): any loaded
+            // alphabet beats the emergency one.
+            it = Alphabets.begin();
+        }
+    }
+    if (it != Alphabets.end()) return it->second;
+    // True last-ditch: nothing loaded at all. Fabricate the emergency
+    // alphabet once. Leaks by design (process-lifetime singleton).
+    static CAlphInfo* emergency = CreateDefault();
+    return emergency;
 }
 
 CAlphInfo* CAlphIO::CreateDefault() {

--- a/src/DasherCore/Alphabet/AlphIO.h
+++ b/src/DasherCore/Alphabet/AlphIO.h
@@ -68,7 +68,10 @@ class Dasher::CAlphIO : public AbstractXMLParser {
     /// same parsing semantics as the full loader (entity references
     /// decoded, both quote styles, any prolog length) without building
     /// any CAlphInfo.
-    void ScanNameIndex();
+    // Index every alphabet name cheaply. With an explicit dir, scans THAT
+    // directory (per-context); without, falls back to FileUtils' process-
+    // global data directory (last-create-wins — legacy single-context hosts).
+    void ScanNameIndex(const std::string& dir = std::string());
 
     /// Full-parse one alphabet file by (absolute or pattern) filename.
     bool LoadAlphabetFile(const std::string& filename);

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -128,13 +128,39 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
     // Heal the RETIRED emergency alphabet id (DasherCore#88): settings from
     // older builds can name "Default" — the bare a-z fallback, which is
     // structurally dead (the engine renders but commits no output however
-    // long you drive; the "no text goes into the output area" report). The
-    // lazy block above already loads the preferred alphabet as the running
-    // one; rewrite SP so pickers and the next settings save hold the healed
-    // id. The parameter event runs ChangeAlphabet on the LOADED id — the
-    // same path as any post-realize alphabet switch.
+    // long you drive; the "no text goes into the output area" report).
+    // The heal must land on an alphabet that ACTUALLY LOADED (greptile P1:
+    // with a custom data dir lacking the preferred English alphabet,
+    // GetDefault() itself returns "Default" and the assignment would no-op
+    // back into the dead id): the preferred, else the first index entry
+    // that parses, else nothing (a data dir with no loadable alphabets
+    // keeps the original last-ditch behaviour). The parameter event runs
+    // ChangeAlphabet on the LOADED id — the same path as any post-realize
+    // alphabet switch.
+    {
+        std::vector<std::string> probe;
+        m_AlphIO->GetAlphabets(&probe);
+    }
     if (m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID) == "Default") {
-        m_pSettingsStore->SetStringParameter(SP_ALPHABET_ID, m_AlphIO->GetDefault());
+        std::string healed;
+        if (m_AlphIO->HasInfo("English with limited punctuation")) {
+            healed = "English with limited punctuation";
+        } else {
+            // Preferred unavailable (custom data dir). The lazy name index
+            // is empty here (nothing has loaded), so listing candidates
+            // cannot work — bulk-load whatever alphabet files the data dir
+            // holds (ScanFiles basename-glob; bounded by the custom dir's
+            // contents) and heal to the first real id that parsed.
+            m_AlphIO->LoadAlphabetFile("alphabet.*.xml");
+            std::vector<std::string> listed;
+            m_AlphIO->GetAlphabets(&listed);
+            for (const std::string& candidate : listed) {
+                if (candidate == "Default") continue;
+                healed = candidate;
+                break;
+            }
+        }
+        if (!healed.empty()) m_pSettingsStore->SetStringParameter(SP_ALPHABET_ID, healed);
     }
 
     m_ColorIO = std::make_unique<CColorIO>(this);

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -125,6 +125,18 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
         if (!m_AlphIO->HasInfo(alphId)) loadById("English with limited punctuation");
     }
 
+    // Heal the RETIRED emergency alphabet id (DasherCore#88): settings from
+    // older builds can name "Default" — the bare a-z fallback, which is
+    // structurally dead (the engine renders but commits no output however
+    // long you drive; the "no text goes into the output area" report). The
+    // lazy block above already loads the preferred alphabet as the running
+    // one; rewrite SP so pickers and the next settings save hold the healed
+    // id. The parameter event runs ChangeAlphabet on the LOADED id — the
+    // same path as any post-realize alphabet switch.
+    if (m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID) == "Default") {
+        m_pSettingsStore->SetStringParameter(SP_ALPHABET_ID, m_AlphIO->GetDefault());
+    }
+
     m_ColorIO = std::make_unique<CColorIO>(this);
     // All shipped palettes live in Data/colours/ now (British spelling,
     // one file per palette, new-format roots; the parser dispatches on the
@@ -232,6 +244,13 @@ void CDasherInterfaceBase::HandleParameterChange(Parameter parameter) {
             new AmortizedPolicy(m_pDasherModel.get(), m_pSettingsStore->GetLongParameter(LP_NODE_BUDGET)));
         break;
     case BP_CONTROL_MODE:
+        // Pre-realize (no NCManager/model yet — e.g. a parameter set before
+        // the first dasher_set_screen_size): nothing to rebuild; the NCManager
+        // ctor calls CreateControlBox() itself and reads the flag, so the
+        // choice applies at realize. (Unguarded this was a latent null-deref,
+        // exposed by the retired "Default" registration shifting create-time
+        // NCManager setup — dasher-project/DasherCore#88.)
+        if (!m_pNCManager || !m_pDasherModel) break;
         // Rebuild control box first (deletes old CControlManager/templates),
         // then rebuild node tree — order is critical to avoid dangling
         // template pointers in live CContNodes during AddExtras().

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -545,7 +545,17 @@ void CDasherInterfaceBase::ChangeAlphabet() {
         if (!m_AlphIO->HasInfo(alphId)) {
             std::string fn = m_AlphIO->FileNameFor(alphId);
             if (fn.empty()) fn = alphabetIdToFilename(alphId);
-            m_AlphIO->LoadAlphabetFile(fn);
+            // Per-context, like the realize path: LoadAlphabetFile scans
+            // FileUtils' global data directory (last-create-wins), which
+            // under multiple live contexts loads the OTHER context's file
+            // under this id (greptile follow-up on #88 — same class the
+            // realize-path fix addressed). Basename-normalise: index entries
+            // can be dir-relative and ScanFiles matches basenames.
+            fn = std::filesystem::path(fn).filename().string();
+            if (!m_dataDir.empty())
+                Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), fn, m_dataDir);
+            else
+                m_AlphIO->LoadAlphabetFile(fn);
         }
     }
 

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -112,11 +112,19 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
     // Android, 270ms → 10–23ms on GTK — full data in
     // dasher-startup-timing-report.md.
     m_AlphIO = std::make_unique<CAlphIO>(this);
-    m_AlphIO->ScanNameIndex();
+    // Per-context index + loads: ScanFiles routes through FileUtils' global
+    // data dir (last-create-wins), so a second context's create would make
+    // THIS realize read the other bundle (greptile P1 #2 on #88 — pinned by
+    // retired_default_heal_uses_own_context_data_dir).
+    m_AlphIO->ScanNameIndex(m_dataDir);
     const auto loadById = [this](const std::string& alphId) {
         std::string fn = m_AlphIO->FileNameFor(alphId);
         if (fn.empty()) fn = alphabetIdToFilename(alphId);
-        m_AlphIO->LoadAlphabetFile(fn);
+        fn = std::filesystem::path(fn).filename().string(); // index entries can be dir-relative
+        if (!m_dataDir.empty())
+            Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), fn, m_dataDir);
+        else
+            m_AlphIO->LoadAlphabetFile(fn);
     };
     {
         std::string alphId = m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID);
@@ -148,10 +156,17 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
         } else {
             // Preferred unavailable (custom data dir). The lazy name index
             // is empty here (nothing has loaded), so listing candidates
-            // cannot work — bulk-load whatever alphabet files the data dir
-            // holds (ScanFiles basename-glob; bounded by the custom dir's
-            // contents) and heal to the first real id that parsed.
-            m_AlphIO->LoadAlphabetFile("alphabet.*.xml");
+            // cannot work — bulk-load whatever alphabet files THIS context's
+            // data dir holds and heal to the first real id that parsed.
+            // ScanDirectory takes the explicit dir: LoadAlphabetFile routes
+            // through ScanFiles' process-global data directory, which belongs
+            // to whichever context was created LAST — realizing a "Default"
+            // profile after creating another context would load (and heal
+            // to) the OTHER context's bundle (greptile P1 #2 on #88).
+            if (!m_dataDir.empty())
+                Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), "alphabet.*.xml", m_dataDir);
+            else
+                m_AlphIO->LoadAlphabetFile("alphabet.*.xml");
             std::vector<std::string> listed;
             m_AlphIO->GetAlphabets(&listed);
             for (const std::string& candidate : listed) {

--- a/src/DasherCore/DasherInterfaceBase.cpp
+++ b/src/DasherCore/DasherInterfaceBase.cpp
@@ -117,15 +117,7 @@ void CDasherInterfaceBase::Realize(unsigned long ulTime) {
     // THIS realize read the other bundle (greptile P1 #2 on #88 — pinned by
     // retired_default_heal_uses_own_context_data_dir).
     m_AlphIO->ScanNameIndex(m_dataDir);
-    const auto loadById = [this](const std::string& alphId) {
-        std::string fn = m_AlphIO->FileNameFor(alphId);
-        if (fn.empty()) fn = alphabetIdToFilename(alphId);
-        fn = std::filesystem::path(fn).filename().string(); // index entries can be dir-relative
-        if (!m_dataDir.empty())
-            Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), fn, m_dataDir);
-        else
-            m_AlphIO->LoadAlphabetFile(fn);
-    };
+    const auto loadById = [this](const std::string& alphId) { LoadAlphabetById(alphId); };
     {
         std::string alphId = m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID);
         if (alphId.empty()) alphId = "English with limited punctuation";
@@ -527,6 +519,34 @@ bool CDasherInterfaceBase::Redraw(unsigned long ulTime, bool bRedrawNodes, CExpa
     return bRedrawNodes;
 }
 
+// On-demand alphabet load for [alphId]. The name index resolves tier
+// preferences (maintained v6 over legacy copies, user-dir overrides) and may
+// hold a directory-qualified path — load THAT file exactly; a basename glob
+// would re-parse every same-named file in traversal order and let the
+// filesystem decide which definition wins (greptile P1 "indexed path
+// selection discarded"). Only a synthesized fallback filename scans by
+// basename, and per-context (ScanDirectory on m_dataDir) — LoadAlphabetFile
+// routes through the process-global data directory.
+void CDasherInterfaceBase::LoadAlphabetById(const std::string& alphId) {
+    const std::string indexed = m_AlphIO->FileNameFor(alphId);
+    if (!indexed.empty()) {
+        std::filesystem::path exact(indexed);
+        if (exact.is_relative()) exact = std::filesystem::weakly_canonical(exact);
+        std::error_code ec;
+        if (std::filesystem::exists(exact, ec)) {
+            Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), exact.string(), m_dataDir);
+            return;
+        }
+        // Indexed file vanished (bundle edited under us): fall through to
+        // the synthesized-name scan below.
+    }
+    const std::string synth = alphabetIdToFilename(alphId);
+    if (!m_dataDir.empty())
+        Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), synth, m_dataDir);
+    else
+        m_AlphIO->LoadAlphabetFile(synth);
+}
+
 void CDasherInterfaceBase::ChangeAlphabet() {
     if (m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID) == "") {
         m_pSettingsStore->SetStringParameter(SP_ALPHABET_ID, m_AlphIO->GetDefault());
@@ -542,21 +562,7 @@ void CDasherInterfaceBase::ChangeAlphabet() {
     // to an unparsed alphabet silently gave the user Default instead.)
     if (m_AlphIO) {
         std::string alphId = m_pSettingsStore->GetStringParameter(SP_ALPHABET_ID);
-        if (!m_AlphIO->HasInfo(alphId)) {
-            std::string fn = m_AlphIO->FileNameFor(alphId);
-            if (fn.empty()) fn = alphabetIdToFilename(alphId);
-            // Per-context, like the realize path: LoadAlphabetFile scans
-            // FileUtils' global data directory (last-create-wins), which
-            // under multiple live contexts loads the OTHER context's file
-            // under this id (greptile follow-up on #88 — same class the
-            // realize-path fix addressed). Basename-normalise: index entries
-            // can be dir-relative and ScanFiles matches basenames.
-            fn = std::filesystem::path(fn).filename().string();
-            if (!m_dataDir.empty())
-                Dasher::FileUtils::ScanDirectory(m_AlphIO.get(), fn, m_dataDir);
-            else
-                m_AlphIO->LoadAlphabetFile(fn);
-        }
+        if (!m_AlphIO->HasInfo(alphId)) LoadAlphabetById(alphId);
     }
 
     if (m_pNCManager) WriteTrainFileFull(); // can't/don't before creating first NCManager

--- a/src/DasherCore/DasherInterfaceBase.h
+++ b/src/DasherCore/DasherInterfaceBase.h
@@ -515,6 +515,7 @@ class Dasher::CDasherInterfaceBase : public CMessageDisplay, private NoClones {
 
     void CreateModel(int iOffset);
     void CreateNCManager();
+    void LoadAlphabetById(const std::string& alphId);
 
     /// Per-context user dir — see SetUserDataDirectory.
     std::string m_userDataDir;

--- a/src/DasherCore/DasherInterfaceBase.h
+++ b/src/DasherCore/DasherInterfaceBase.h
@@ -378,6 +378,13 @@ class Dasher::CDasherInterfaceBase : public CMessageDisplay, private NoClones {
     void SetUserDataDirectory(const std::string& dir) { m_userDataDir = dir; }
     const std::string& GetUserDataDirectory() const { return m_userDataDir; }
 
+    /// Per-context bundled data directory (read-only corpora), same
+    /// last-created-context rationale as SetUserDataDirectory: the startup
+    /// training scan must read THIS context's data dir, not the global.
+    /// Empty = fall back to the global (legacy single-context embedders).
+    void SetDataDirectory(const std::string& dir) { m_dataDir = dir; }
+    const std::string& GetDataDirectory() const { return m_dataDir; }
+
     /// Relative filename of the current alphabet's user training file (e.g.
     /// "training_english_GB.txt"), or "" when no model is realized or the
     /// alphabet declares no training file. Callers resolve it against THEIR
@@ -511,6 +518,9 @@ class Dasher::CDasherInterfaceBase : public CMessageDisplay, private NoClones {
 
     /// Per-context user dir — see SetUserDataDirectory.
     std::string m_userDataDir;
+
+    /// Per-context bundled data dir — see SetDataDirectory.
+    std::string m_dataDir;
 
     void ChangeAlphabet();
     void ChangeColors();

--- a/src/DasherCore/FileUtils.cpp
+++ b/src/DasherCore/FileUtils.cpp
@@ -56,18 +56,29 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
         return;
     }
 
+    ScanDirectory(parser, strPattern, s_dataDirectory);
+}
+
+void Dasher::FileUtils::ScanDirectory(AbstractParser* parser, const std::string& strPattern, const std::string& dir) {
+    // Same absolute-path contract as ScanFiles: one specific file, no glob.
+    std::error_code error_code;
+    std::filesystem::path p(strPattern);
+    if (p.is_absolute()) {
+        if (std::filesystem::exists(p, error_code) && std::filesystem::is_regular_file(p, error_code)) {
+            parser->ParseFile(strPattern, IsFileWriteable(strPattern));
+        }
+        return;
+    }
+
     // Replace * with .* for actual regex matching
     // Note: pattern is interpreted as regex, so "alphabet.*.xml" matches "alphabet.English.xml"
     const std::regex pattern = std::regex(strPattern);
 
-    // Search ONLY in the specified data directory. The old fallback to
-    // current_path() turned an empty/missing data dir (frontend passed a bad
-    // bundle path) into an unbounded scan of the user's home directory —
-    // minutes of regex per file while the caller held its engine lock
-    // (watch spike hang, 2026-08-31). No data dir means nothing to scan.
+    // Search ONLY in the specified directory; empty means nothing to scan
+    // (same rationale as ScanFiles — never fall back to current_path()).
     std::vector<std::filesystem::path> search_paths;
-    if (!s_dataDirectory.empty()) {
-        search_paths.push_back(std::filesystem::path(s_dataDirectory));
+    if (!dir.empty()) {
+        search_paths.push_back(std::filesystem::path(dir));
     }
 
     for (const std::filesystem::path& current_path : search_paths) {
@@ -129,6 +140,27 @@ void Dasher::FileUtils::ScanFiles(AbstractParser* parser, const std::string& str
             }
         }
     }
+}
+
+bool Dasher::FileUtils::IsSameDirectory(const std::string& a, const std::string& b) {
+    if (a.empty() || b.empty()) return false;
+    std::error_code ec;
+    std::filesystem::path pa(a), pb(b);
+    if (std::filesystem::exists(pa, ec) && !ec && std::filesystem::exists(pb, ec) && !ec) {
+        // Resolves symlinks / junctions and (on Windows) case-insensitivity.
+        ec.clear();
+        bool eq = std::filesystem::equivalent(pa, pb, ec);
+        if (!ec) return eq;
+        // exists() said yes but equivalent() failed (e.g. permission on a
+        // parent) — fall through to the lexical comparison below.
+    }
+    ec.clear();
+    const auto na = std::filesystem::weakly_canonical(pa, ec);
+    if (ec) return false;
+    ec.clear();
+    const auto nb = std::filesystem::weakly_canonical(pb, ec);
+    if (ec) return false;
+    return na == nb;
 }
 
 bool Dasher::FileUtils::WriteUserDataFile(const std::string& filename, const std::string& strNewText, bool append) {

--- a/src/DasherCore/FileUtils.h
+++ b/src/DasherCore/FileUtils.h
@@ -24,6 +24,19 @@ class FileUtils {
     // Open File with the filename strPattern in the project directory
     static void ScanFiles(AbstractParser* parser, const std::string& strPattern);
 
+    // Scan a specific directory (recursively) instead of the process-global
+    // data directory. Same pattern semantics as ScanFiles; an empty dir
+    // scans nothing. Lets per-context callers (NodeCreationManager training
+    // load, dasher-project/DasherCore#84) avoid the last-created-context
+    // globals that ScanFiles consults.
+    static void ScanDirectory(AbstractParser* parser, const std::string& strPattern, const std::string& dir);
+
+    // True when two directory paths name the same location: uses
+    // std::filesystem::equivalent when both exist (symlinks, junctions,
+    // case-insensitive roots), falling back to weakly_canonical lexical
+    // comparison for not-yet-created dirs. Empty paths never match.
+    static bool IsSameDirectory(const std::string& a, const std::string& b);
+
     // Writes into the user file
     static bool WriteUserDataFile(const std::string& filename, const std::string& strNewText, bool append);
 

--- a/src/DasherCore/NodeCreationManager.cpp
+++ b/src/DasherCore/NodeCreationManager.cpp
@@ -98,7 +98,25 @@ CNodeCreationManager::CNodeCreationManager(CSettingsStore* pSettingsStore, CDash
 
     if (!pAlphInfo->GetTrainingFile().empty()) {
         ProgressNotifier pn(pInterface, m_pTrainer);
-        Dasher::FileUtils::ScanFiles(&pn, pAlphInfo->GetTrainingFile());
+        // Per-context dirs (#84): train from the bundled corpus in THIS
+        // context's data dir, then from the user's accumulated training in
+        // THIS context's user dir. Adaptive appends land in the user dir
+        // (ResolveUserDataPath), so skipping it silently discarded all
+        // learning from previous sessions on every frontend that separates
+        // the two dirs (Android, GTK, Apple) — only Windows survived, by
+        // passing one dir for both. User-dir scan runs LAST so the
+        // ProgressNotifier's user/system flags describe the newest file
+        // (they reset per Parse) and the "may not be learning" hint stays
+        // accurate. Skipped entirely when the dirs are one and the same, so
+        // single-dir setups never double-train.
+        const std::string& dataDir = pInterface->GetDataDirectory();
+        const std::string& userDir = pInterface->GetUserDataDirectory();
+        if (!dataDir.empty())
+            Dasher::FileUtils::ScanDirectory(&pn, pAlphInfo->GetTrainingFile(), dataDir);
+        else
+            Dasher::FileUtils::ScanFiles(&pn, pAlphInfo->GetTrainingFile()); // legacy: global data dir
+        if (!userDir.empty() && !Dasher::FileUtils::IsSameDirectory(userDir, dataDir))
+            Dasher::FileUtils::ScanDirectory(&pn, pAlphInfo->GetTrainingFile(), userDir);
         if (!pn.has_parsed_from_user_dir()) {
             /// TRANSLATORS: These 3 messages will be displayed when the user has just chosen a new alphabet. The %s
             /// parameter will be the name of the alphabet.

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -593,6 +593,19 @@ DASHER_API int dasher_import_training_text(dasher_ctx* ctx, const char* text);
 // dasher-project/Dasher-Windows#53).
 DASHER_API const char* dasher_get_training_path(dasher_ctx* ctx);
 
+// C API version, incremented when a behavioural change frontends might
+// condition on lands. Frontends should gate compatibility workarounds on
+// this rather than probing for symbols.
+//
+//   1 — startup training load scans the per-context USER data directory in
+//       addition to the bundled data dir, so split-dir frontends (Android,
+//       GTK, Apple) finally load learning accumulated in previous sessions
+//       (DasherCore#84). A frontend that re-imports the training file after
+//       create as a stopgap MUST skip that re-import at version >= 1 or the
+//       text would be counted twice.
+DASHER_API int dasher_capi_version(void);
+#define DASHER_CAPI_VERSION 1
+
 // Get the current Dasher offset (character position in the output).
 // Returns -1 if the engine is not realized.
 DASHER_API int dasher_get_offset(dasher_ctx* ctx);

--- a/tests/test_alphabet_xml.cpp
+++ b/tests/test_alphabet_xml.cpp
@@ -477,3 +477,57 @@ TEST(retired_default_alphabet_id_heals_to_real_alphabet) {
     printf("  output after drive: '%s'\n", text);
     dasher_destroy(ctx);
 }
+
+TEST(retired_default_heals_in_custom_data_dir_without_preferred) {
+    // Greptile P1 on #88: a custom data dir with alphabets but WITHOUT the
+    // preferred "English with limited punctuation" — GetDefault() returns
+    // the literal "Default", so the heal must fall back to the first index
+    // entry that actually parses, not no-op back into the dead id.
+    ScopedTempDir dataRoot;
+    std::filesystem::path data = std::filesystem::path(dataRoot.path) / "Data";
+    std::filesystem::create_directories(data / "alphabets");
+    std::filesystem::create_directories(data / "training");
+    // Only one alphabet, deliberately NOT the preferred English one, plus
+    // the training corpus it names.
+    std::error_code ec;
+    // TEST_DATA_DIR is the REPO ROOT (CMakeLists sets it to
+    // CMAKE_CURRENT_LIST_DIR); the shipped files live under Data/.
+    std::filesystem::copy_file(std::filesystem::path(TEST_DATA_DIR) / "Data" / "alphabets" /
+                                   "alphabet.english.without.punctuation.xml",
+                               data / "alphabets" / "alphabet.english.without.punctuation.xml", ec);
+    ec.clear();
+    std::filesystem::copy_file(std::filesystem::path(TEST_DATA_DIR) / "Data" / "training" / "training_english_GB.txt",
+                               data / "training" / "training_english_GB.txt", ec);
+
+    ScopedTempDir user;
+    {
+        std::ofstream out(std::filesystem::path(user.path) / "dasher_settings.xml");
+        out << "<?xml version=\"1.0\"?>\n<settings>\n"
+            << "  <string name=\"AlphabetID\" value=\"Default\" />\n</settings>\n";
+    }
+    // NOTE: dasher_create's data_dir is the DATA directory itself (TEST_DATA_DIR
+    // is "./Data"), not its parent.
+    dasher_ctx* ctx = dasher_create(data.string().c_str(), user.c_str(), nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    const char* alph = dasher_get_alphabet_id(ctx);
+    printf("  healed in custom dir: '%s'\n", alph);
+    ASSERT(strcmp(alph, "Default") != 0); // healed to the one available alphabet
+
+    dasher_set_speed_percent(ctx, 300);
+    dasher_mouse_move(ctx, 700.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 500; i++) {
+        dasher_mouse_move(ctx, 700.0f, 280.0f);
+        int* c = nullptr;
+        int cc = 0;
+        char** s2 = nullptr;
+        int sc = 0;
+        dasher_frame(ctx, 1000 + i * 20, &c, &cc, &s2, &sc);
+    }
+    dasher_mouse_up(ctx);
+    const char* text = dasher_get_output_text(ctx);
+    ASSERT(text && strlen(text) > 0);
+    printf("  output after drive: '%s'\n", text);
+    dasher_destroy(ctx);
+}

--- a/tests/test_alphabet_xml.cpp
+++ b/tests/test_alphabet_xml.cpp
@@ -440,3 +440,40 @@ TEST(alphabet_v5_special_chars_as_direct_children) {
 
     dasher_destroy(ctx);
 }
+
+TEST(retired_default_alphabet_id_heals_to_real_alphabet) {
+    // The bare a-z "Default" emergency alphabet is no longer registered
+    // eagerly: it was selectable/persistable and structurally dead (driving
+    // committed no output — "no text goes into the output area" report).
+    // A saved Default id must heal to a real alphabet AND drive.
+    ScopedTempDir user;
+    {
+        std::ofstream out(std::filesystem::path(user.path) / "dasher_settings.xml");
+        out << "<?xml version=\"1.0\"?>\n<settings>\n"
+            << "  <string name=\"AlphabetID\" value=\"Default\" />\n</settings>\n";
+    }
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, user.c_str(), nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    const char* alph = dasher_get_alphabet_id(ctx);
+    printf("  healed alphabet: '%s'\n", alph);
+    ASSERT(strcmp(alph, "Default") != 0); // healed to a real alphabet
+
+    // And it drives (canonical interaction recipe).
+    dasher_set_speed_percent(ctx, 300);
+    dasher_mouse_move(ctx, 700.0f, 300.0f);
+    dasher_mouse_down(ctx);
+    for (int i = 0; i < 500; i++) {
+        dasher_mouse_move(ctx, 700.0f, 280.0f);
+        int* c = nullptr;
+        int cc = 0;
+        char** s = nullptr;
+        int sc = 0;
+        dasher_frame(ctx, 1000 + i * 20, &c, &cc, &s, &sc);
+    }
+    dasher_mouse_up(ctx);
+    const char* text = dasher_get_output_text(ctx);
+    ASSERT(text && strlen(text) > 0);
+    printf("  output after drive: '%s'\n", text);
+    dasher_destroy(ctx);
+}

--- a/tests/test_alphabet_xml.cpp
+++ b/tests/test_alphabet_xml.cpp
@@ -531,3 +531,39 @@ TEST(retired_default_heals_in_custom_data_dir_without_preferred) {
     printf("  output after drive: '%s'\n", text);
     dasher_destroy(ctx);
 }
+
+TEST(retired_default_heal_uses_own_context_data_dir) {
+    // Greptile P1 #2 on #88: with two contexts alive (created A-custom then
+    // B-full), realizing A must bulk-scan A's data dir — not the
+    // process-global (last-create-wins) directory, which is B's. Without the
+    // per-context scan A would heal to B's preferred alphabet, selecting an
+    // id unavailable in its own bundle.
+    ScopedTempDir dataRootCustom;
+    std::filesystem::path custom = std::filesystem::path(dataRootCustom.path) / "Data";
+    std::filesystem::create_directories(custom / "alphabets");
+    std::filesystem::create_directories(custom / "training");
+    std::error_code ec;
+    std::filesystem::copy_file(std::filesystem::path(TEST_DATA_DIR) / "Data" / "alphabets" /
+                                   "alphabet.english.without.punctuation.xml",
+                               custom / "alphabets" / "alphabet.english.without.punctuation.xml", ec);
+    std::filesystem::copy_file(std::filesystem::path(TEST_DATA_DIR) / "Data" / "training" / "training_english_GB.txt",
+                               custom / "training" / "training_english_GB.txt", ec);
+
+    ScopedTempDir userA, userB;
+    {
+        std::ofstream out(std::filesystem::path(userA.path) / "dasher_settings.xml");
+        out << "<?xml version=\"1.0\"?>\n<settings>\n"
+            << "  <string name=\"AlphabetID\" value=\"Default\" />\n</settings>\n";
+    }
+
+    // Create A (custom), then B (full) — the global now points at B's dir.
+    dasher_ctx* a = dasher_create(custom.string().c_str(), userA.c_str(), nullptr);
+    dasher_ctx* b = dasher_create(TEST_DATA_DIR, userB.c_str(), nullptr);
+    ASSERT(a && b);
+    dasher_set_screen_size(a, 800, 600); // realize A LAST-created-other: must still use A's dir
+    const char* alphA = dasher_get_alphabet_id(a);
+    printf("  A healed to: '%s'\n", alphA);
+    ASSERT_STR_EQ(alphA, "English without punctuation"); // A's own, not B's preferred
+    dasher_destroy(a);
+    dasher_destroy(b);
+}

--- a/tests/test_training.cpp
+++ b/tests/test_training.cpp
@@ -1,5 +1,7 @@
 // Training adaptation tests: verify training text changes model behavior
 #include "test_common.h"
+#include <fstream>
+
 static unsigned long hash_probabilities(dasher_ctx* ctx) {
     int lbnds[256], hbnds[256];
     int n = dasher_get_probabilities(ctx, lbnds, hbnds, 256);
@@ -10,6 +12,98 @@ static unsigned long hash_probabilities(dasher_ctx* ctx) {
         h = ((h << 5) + h) + hbnds[i];
     }
     return h;
+}
+
+// Writes a distinctive corpus as the engine would have accumulated it (the
+// user-dir ROOT is where ResolveUserDataPath appends).
+static void write_user_training(const ScopedTempDir& dir, const char* text, int repeat) {
+    std::ofstream out(std::filesystem::path(dir.path) / "training_english_GB.txt", std::ios::app);
+    for (int i = 0; i < repeat; i++)
+        out << text;
+}
+
+TEST(capi_version_reports_user_dir_scan) {
+    // Version 1 = startup training load includes the per-context user dir
+    // (DasherCore#84). Frontends gate their stopgap re-import on this.
+    printf("  capi version: %d\n", dasher_capi_version());
+    ASSERT(dasher_capi_version() >= 1);
+}
+
+TEST(training_user_dir_loaded_at_startup) {
+    // Baseline: fresh user dir, nothing accumulated.
+    unsigned long baseline;
+    {
+        ScopedContext ctx(800, 600);
+        run_frames(ctx, 3);
+        baseline = hash_probabilities(ctx);
+    }
+    ASSERT(baseline != 0);
+
+    // Same data dir; user dir pre-populated with accumulated training in the
+    // location the engine itself appends to. The startup scan must load it —
+    // before #84 the scan walked the data dir only and split-dir frontends
+    // lost all learning between sessions.
+    ScopedTempDir userDir;
+    write_user_training(userDir, "xyzzy quork zumble flibbertigibbet zatch ", 60);
+
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, userDir.c_str(), nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    run_frames(ctx, 3);
+    unsigned long trained = hash_probabilities(ctx);
+    dasher_destroy(ctx);
+
+    printf("  baseline=%lu trained=%lu\n", baseline, trained);
+    ASSERT(trained != 0);
+    ASSERT(trained != baseline);
+}
+
+TEST(training_scan_is_per_context) {
+    // Context A has accumulated training; context B is created AFTER A, so
+    // the process-global FileUtils dirs belong to A. B (fresh user dir) must
+    // match the no-training baseline — its scan reads interface-owned dirs,
+    // not the globals (DasherCore#84 / last-create-wins wrinkle).
+    unsigned long baseline;
+    {
+        ScopedContext ctx(800, 600);
+        run_frames(ctx, 3);
+        baseline = hash_probabilities(ctx);
+    }
+    ASSERT(baseline != 0);
+
+    ScopedTempDir dirA;
+    write_user_training(dirA, "asymmetric corpus unique to context a brangler ", 60);
+    dasher_ctx* a = dasher_create(TEST_DATA_DIR, dirA.c_str(), nullptr);
+    ASSERT(a);
+    dasher_set_screen_size(a, 800, 600);
+    run_frames(a, 3);
+
+    ScopedContext b(800, 600); // created after A — globals point at A's dirs
+    run_frames(b, 3);
+    unsigned long hashB = hash_probabilities(b);
+
+    dasher_destroy(a);
+
+    printf("  baseline=%lu b=%lu\n", baseline, hashB);
+    ASSERT_EQ(hashB, baseline);
+}
+
+TEST(training_same_dir_setup_remains_valid) {
+    // Windows-style single-dir setup (data dir == user dir): the user-dir
+    // scan is skipped so nothing double-trains; engine realizes normally
+    // and probabilities stay normalized.
+    dasher_ctx* ctx = dasher_create(TEST_DATA_DIR, TEST_DATA_DIR, nullptr);
+    ASSERT(ctx);
+    dasher_set_screen_size(ctx, 800, 600);
+    run_frames(ctx, 3);
+
+    int lbnds[256], hbnds[256];
+    int n = dasher_get_probabilities(ctx, lbnds, hbnds, 256);
+    ASSERT(n > 0);
+    ASSERT_EQ(hbnds[n - 1], 65536);
+
+    dasher_destroy(ctx);
+    printf("  single-dir setup: %d children, normalized OK\n", n);
 }
 
 TEST(training_import_returns_success) {


### PR DESCRIPTION
## Live-reported bug

> "as I drive it I dont see any text go into the output text writing area" — Dasher-GTK, tonight

Root cause, isolated by an engine-level repro on the reporter's actual profile: their settings held `AlphabetID="Default"` — the bare a–z **"last ditch" fallback alphabet** that `CAlphIO`'s constructor registered **unconditionally**. That alphabet is **structurally dead**: with it selected, the engine renders, reports no error, and **commits no output however long you drive** (no space, no newline, no groups). Because it was registered like any real alphabet, it appeared in pickers' permitted values and round-tripped through settings.

The editor-contract work was exonerated by the repro: with a fresh profile the same binary drives text into the pane normally.

## Fix

1. **`CAlphIO` no longer eagerly registers `"Default"`** — it disappears from pickers/permitted values. `GetInfo` falls back to the preferred real alphabet; the emergency alphabet is fabricated (once, lazily) only when *nothing at all* loaded — the case it was written for.
2. **`Realize()` heals `SP_ALPHABET_ID == "Default"`** to the loaded default, after the lazy alphabet-load block — pickers and the next settings save hold the healed id. Old settings self-heal on first launch after upgrade.
3. **`HandleParameterChange(BP_CONTROL_MODE)`: null guard.** Setting control mode pre-realize was a latent null-deref (no NCManager yet); exposed by the create-flow shift, fixed properly — the NCManager ctor reads the flag, so pre-realize sets still apply at realize.

## Two collateral traps dodged (documented in the investigation)

- Healing inside `ChangeAlphabet` broke the on-demand alphabet loader and `set_string_parameter`'s stored-value contract (the "English, lower case" comma-normalisation wrinkle: name index vs parsed-name mismatch — worth its own issue).
- The guard-less control-mode case segfaulted only because the retired registration shifted when the NCManager first exists.

## Tests

New regression case in `dasher_alphabet_xml_tests`: settings naming `Default` heal to `'English with limited punctuation'` **and** the canonical drive produces output. Full matrix **43/43**; clang-format clean.

## Frontend follow-ups

- Dasher-GTK carries the live repro as an engine-contract regression test + submodule bump (PR follows).
- Reporter's immediate workaround (pre-merge): switch the alphabet picker off "Default" — e.g. "English with limited punctuation".

DCO signed.









<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62851890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; no actionable new defect or outstanding blocking finding remains.

<h3>Summary</h3>

- Lazily creates the emergency alphabet only when no real alphabet can be loaded.
- Resolves indexed alphabet files by their selected exact path.
- Prevents multiple C API contexts from reading each other’s data directories.
- Restores accumulated user training at startup without double-loading single-directory configurations.
- Guards control-mode changes made before realization.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Realize context] --> B[Scan this context's alphabet index]
    B --> C[Load configured alphabet by exact indexed path]
    C --> D{Stored ID is Default?}
    D -- No --> G[Create model and node manager]
    D -- Yes --> E{Preferred alphabet loaded?}
    E -- Yes --> F[Persist preferred real ID]
    E -- No --> H[Load real alphabets from this context's data directory]
    H --> I{Any real alphabet loaded?}
    I -- Yes --> J[Persist first loaded real ID]
    I -- No --> K[Retain last-ditch emergency behavior]
    F --> G
    J --> G
    K --> G
    G --> L[Load bundled training corpus]
    L --> M{User and data directories differ?}
    M -- Yes --> N[Load accumulated user training]
    M -- No --> O[Skip duplicate scan]
```
</details>

<sub>Reviews (5) · Last reviewed commit: ["fix: on-demand load honours the indexed ..."](https://github.com/dasher-project/dashercore/commit/cb1d59df0ca55f3c3f690d184db83d8958f75be4)</sub>

<!-- /greptile_comment -->