### PR TITLE
feat(build): VERSIONINFO resource for dasher.dll (v0.2.23)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project("DasherCore")
+project("DasherCore" VERSION 0.2.23)
 
 enable_testing()
 
@@ -185,6 +185,21 @@ if(BUILD_CAPI)
     if(WIN32)
         target_compile_definitions(dasher PRIVATE DASHER_BUILDING)
         target_compile_options(dasher PRIVATE /EHa)
+
+        # VERSIONINFO resource (Dasher-Windows #59): an unversioned DLL let
+        # MSI upgrade heuristics keep stale copies under a new EXE; a
+        # FILEVERSION makes newer-always-wins deterministic. Keep project()
+        # VERSION in lockstep with the release tag.
+        string(REPLACE "." ";" _dasher_ver_list ${PROJECT_VERSION})
+        list(GET _dasher_ver_list 0 DASHER_VERSION_MAJOR)
+        list(GET _dasher_ver_list 1 DASHER_VERSION_MINOR)
+        list(GET _dasher_ver_list 2 DASHER_VERSION_PATCH)
+        set(DASHER_VERSION_STRING "${PROJECT_VERSION}.0")
+        configure_file(
+            ${CMAKE_CURRENT_LIST_DIR}/src/dasher_version.rc.in
+            ${CMAKE_CURRENT_BINARY_DIR}/dasher_version.rc
+            @ONLY)
+        target_sources(dasher PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/dasher_version.rc)
     endif()
 
     set_target_properties(dasher PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,54 @@ cmake_minimum_required(VERSION 3.12)
 
 project("DasherCore" VERSION 0.2.23)
 
+###############################
+# Release-version drift guard
+###############################
+# The DLL's FILEVERSION comes from project() VERSION above, and MSI upgrade
+# correctness depends on it advancing with EVERY release (#89). Nothing else
+# ties that number to the release tag, so a tag pushed without bumping this
+# line would ship a DLL with the PREVIOUS version — silently reintroducing
+# the stale-DLL upgrade bug this resource exists to fix. When building FROM
+# a release tag, the tag must match project() VERSION exactly or the
+# configure step fails:
+#   - CI tag builds: GITHUB_REF=refs/tags/vX.Y.Z (works in shallow
+#     checkouts where the tag object isn't fetched)
+#   - local tag checkouts: `git describe --tags --exact-match`
+# Non-tag builds (branches, PRs, dev trees) are unconstrained.
+set(_dasher_tag_version "")
+# CI tag builds: GITHUB_REF=refs/tags/vX.Y.Z. ONLY in DasherCore's own CI —
+# when Dasher-Windows' installer workflow builds the submodule, GITHUB_REF is
+# the WINDOWS tag (e.g. v0.1.29), which must not be compared against the
+# engine version. GITHUB_REPOSITORY distinguishes the two.
+if("$ENV{GITHUB_REPOSITORY}" STREQUAL "dasher-project/DasherCore"
+        AND DEFINED ENV{GITHUB_REF}
+        AND "$ENV{GITHUB_REF}" MATCHES "^refs/tags/v([0-9]+\\.[0-9]+\\.[0-9]+)$")
+    set(_dasher_tag_version "${CMAKE_MATCH_1}")
+else()
+    execute_process(
+        COMMAND git describe --tags --exact-match --match "v[0-9]*"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE _dasher_git_tag
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _dasher_git_result
+        ERROR_QUIET
+        # NOTE: do NOT add OUTPUT_QUIET here — on execute_process it
+        # suppresses the variable CAPTURE, not just printing; with it the
+        # tag reads back empty and the guard never fires (found the hard
+        # way: the mismatch test silently passed).
+    )
+    if(_dasher_git_result EQUAL 0 AND _dasher_git_tag MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)$")
+        set(_dasher_tag_version "${CMAKE_MATCH_1}")
+    endif()
+endif()
+
+if(_dasher_tag_version AND NOT _dasher_tag_version STREQUAL PROJECT_VERSION)
+    message(FATAL_ERROR
+        "Release tag v${_dasher_tag_version} does not match project VERSION ${PROJECT_VERSION}. "
+        "Bump project(... VERSION ...) in CMakeLists.txt before tagging — the DLL FILEVERSION "
+        "must advance with every release or MSI upgrades can keep stale DLLs (see #89).")
+endif()
+
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/dasher_version.rc.in
+++ b/src/dasher_version.rc.in
@@ -1,0 +1,41 @@
+// VERSIONINFO resource for dasher.dll (Dasher-Windows #59 root-cause fix).
+//
+// The DLL previously shipped UNVERSIONED, so Windows Installer's
+// file-versioning rules fell back to date/hash heuristics on upgrades -
+// which could preserve a stale dasher.dll under a new EXE and crash the app
+// with EntryPointNotFoundException on exports that didn't exist in the old
+// engine. A versioned file is compared by FILEVERSION: newer always wins.
+//
+// Configured by CMake from project(DasherCore VERSION ...); keep the tag and
+// the project() version in lockstep when cutting a release.
+
+#include <windows.h>
+
+1 VERSIONINFO
+FILEVERSION     @DASHER_VERSION_MAJOR@,@DASHER_VERSION_MINOR@,@DASHER_VERSION_PATCH@,0
+PRODUCTVERSION  @DASHER_VERSION_MAJOR@,@DASHER_VERSION_MINOR@,@DASHER_VERSION_PATCH@,0
+FILEFLAGSMASK   0x3fL
+FILEFLAGS       0x0L
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "The Dasher Project"
+            VALUE "FileDescription",  "Dasher predictive-text engine"
+            VALUE "FileVersion",      "@DASHER_VERSION_STRING@"
+            VALUE "InternalName",     "dasher"
+            VALUE "LegalCopyright",   "MIT License"
+            VALUE "OriginalFilename", "dasher.dll"
+            VALUE "ProductName",      "DasherCore"
+            VALUE "ProductVersion",   "@DASHER_VERSION_STRING@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
## What

Closes the Dasher-Windows #59 root cause: the DLL shipped **unversioned** (empty `FileVersion`), so Windows Installer's file-versioning rules fell back to date/hash heuristics on upgrades — which could preserve a **stale dasher.dll under a new EXE**, crashing the app with `EntryPointNotFoundException` on exports that didn't exist in the old engine (verified on a real install: `dasher_seed_buffer`, `dasher_set_offset`, `dasher_get_training_path` all absent from a v0.1.25-era copy). A versioned file is compared by `FILEVERSION`: **newer always wins**, deterministically.

- `project(DasherCore VERSION 0.2.23)` is now the single version source — keep in lockstep with the release tag; this PR should be tagged **v0.2.23**
- `src/dasher_version.rc.in` configured per build with the version quad + strings (`FileDescription "Dasher predictive-text engine"`, `OriginalFilename dasher.dll`, MIT, codepage 1200)
- **WIN32-guarded** — `.so`/`.dylib` builds untouched

## Verified

- Build output reports `FileVersion 0.2.23.0` / `ProductVersion 0.2.23.0`
- Full engine test matrix: 0 failures

## Windows-side follow-up (after re-pin)

The Dasher-Windows engine-export contract test will additionally assert a non-empty `FileVersion`, so an unversioned DLL can never ship again.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63017214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the prior version-drift concern is addressed and no new actionable failures were identified.

<h3>Summary</h3>

- Establishes `project(DasherCore VERSION 0.2.23)` as the DLL resource version source.
- Generates and compiles a Windows-only resource containing file and product version metadata.
- Adds a configure-time check that rejects release tags inconsistent with the declared project version.
- Leaves non-Windows library builds unchanged.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Tag["Release tag vX.Y.Z"] --> Guard["CMake version-alignment guard"]
    Project["project VERSION X.Y.Z"] --> Guard
    Guard -->|match| Configure["Configure Windows build"]
    Guard -->|mismatch| Fail["Fail configuration"]
    Project --> Resource["Configure dasher_version.rc"]
    Resource --> DLL["dasher.dll with VERSIONINFO"]
    DLL --> MSI["Deterministic MSI file-version comparison"]
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["fix(build): harden the release-version d..."](https://github.com/dasher-project/dashercore/commit/21b9fe7b906e2dce8b3778a8235de8bea219320a)</sub>

<!-- /greptile_comment -->