### PR TITLE
feat(capi): Phase 4 — string-sentinel unification (CAPI v2) + permitted-value memoization

### DIFF
--- a/docs/C_API.md
+++ b/docs/C_API.md
@@ -569,7 +569,7 @@ DasherCore owns a light/dark appearance model so frontends don't each reinvent t
 
 ```c
 int         dasher_get_palette_appearance(dasher_ctx* ctx, int index);   // DASHER_PALETTE_APPEARANCE_*; -1=oor
-const char* dasher_find_companion_palette(dasher_ctx* ctx, const char* palette_name); // NULL if none
+const char* dasher_find_companion_palette(dasher_ctx* ctx, const char* palette_name); // "" if none (v2; was NULL)
 
 int         dasher_get_appearance_mode(dasher_ctx* ctx);                 // DASHER_APPEARANCE_MODE_*
 void        dasher_set_appearance_mode(dasher_ctx* ctx, int mode);

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -54,18 +54,19 @@
 // behaviour overrides are defined here, out-of-line.
 
 struct dasher_ctx::Interface : public Dasher::CDashIntfScreenMsgs {
-    Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
-        s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
-            // Invalidate the permitted-value cache (todo.md 4.3): any
-            // parameter change may have rebuilt engine-side lists. The
-            // base class subscribes its own handler BEFORE this lambda
-            // fires, so alphabet on-demand loads triggered by the change
-            // are already complete when the generation bumps.
-            ++m_owner->paramGeneration;
-            if (m_owner->callbacks.paramCb)
-                m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
-        });
-    }
+        Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
+            s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
+                if (m_owner->callbacks.paramCb)
+                    m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
+                // Invalidate the permitted-value cache (todo.md 4.3). Deliberately
+                // AFTER the frontend callback: Event::Broadcast does not guarantee
+                // subscriber call order (see Event.h), so robustness here comes
+                // from laziness of refill — permittedValues() re-queries on the
+                // NEXT call, after every handler and re-entrant frontend access
+                // have settled — never from ordering assumptions.
+                ++m_owner->paramGeneration;
+            });
+        }
     ~Interface() { m_pSettingsStore->OnParameterChanged.Unsubscribe(m_owner); }
     void CreateModules() override {
         CDashIntfScreenMsgs::CreateModules();

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -56,14 +56,19 @@
 struct dasher_ctx::Interface : public Dasher::CDashIntfScreenMsgs {
     Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
         s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
+            // Permitted-cache invalidation (todo.md 4.3), split around the
+            // frontend callback so BOTH re-entrancy hazards are covered without
+            // depending on Event::Broadcast call order (which Event.h
+            // explicitly disclaims):
+            // - invalidatePermittedCache BEFORE the callback: a frontend that
+            //   re-queries a list from inside the notification gets a fresh
+            //   refill, not the pre-change cached value (greptile, PR #91).
+            // - ++paramGeneration AFTER: any refill that happened during a
+            //   re-entrant callback is flagged stale, so the next query after
+            //   the whole broadcast settles re-reads once more.
+            capi::invalidatePermittedCache(m_owner);
             if (m_owner->callbacks.paramCb)
                 m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
-            // Invalidate the permitted-value cache (todo.md 4.3). Deliberately
-            // AFTER the frontend callback: Event::Broadcast does not guarantee
-            // subscriber call order (see Event.h), so robustness here comes
-            // from laziness of refill — permittedValues() re-queries on the
-            // NEXT call, after every handler and re-entrant frontend access
-            // have settled — never from ordering assumptions.
             ++m_owner->paramGeneration;
         });
     }

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -56,6 +56,12 @@
 struct dasher_ctx::Interface : public Dasher::CDashIntfScreenMsgs {
     Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
         s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
+            // Invalidate the permitted-value cache (todo.md 4.3): any
+            // parameter change may have rebuilt engine-side lists. The
+            // base class subscribes its own handler BEFORE this lambda
+            // fires, so alphabet on-demand loads triggered by the change
+            // are already complete when the generation bumps.
+            ++m_owner->paramGeneration;
             if (m_owner->callbacks.paramCb)
                 m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
         });
@@ -356,6 +362,11 @@ DASHER_API void dasher_set_screen_size(dasher_ctx* ctx, int width, int height) {
             return;
         }
         ctx->realized = true;
+        // Realize (re)populated the permitted-value lists silently — see
+        // capi::invalidatePermittedCache. Covers both first realize and the
+        // failed-realize retry path above (the cache outlives the recreated
+        // Interface because it lives on the ctx).
+        capi::invalidatePermittedCache(ctx);
         // A successful (re)realize rebuilt the interface from scratch, so an
         // engineError latched by a previous failed Realize is obsolete. That
         // failed-Realize path is the only one that latches while !realized

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -620,19 +620,18 @@ DASHER_API int dasher_color_get_blue(int argb) {
 }
 
 // ── Colour palettes ───────────────────────────────────────────────────────
+// (List getters share the permittedValues cache — CAPI_internal.h.)
 
 DASHER_API int dasher_get_palette_count(dasher_ctx* ctx) {
     if (!ctx || !ctx->intf) return 0;
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_COLOUR_ID);
-    return static_cast<int>(names.size());
+    return static_cast<int>(capi::permittedValues(ctx, Dasher::SP_COLOUR_ID).size());
 }
 
 DASHER_API const char* dasher_get_palette_name(dasher_ctx* ctx, int index) {
     if (!ctx || !ctx->intf) return "";
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_COLOUR_ID);
+    const auto& names = capi::permittedValues(ctx, Dasher::SP_COLOUR_ID);
     if (index < 0 || index >= static_cast<int>(names.size())) return "";
-    ctx->scratch.stringValues = std::move(names);
-    return ctx->scratch.stringValues[index].c_str();
+    return names[index].c_str();
 }
 
 DASHER_API const char* dasher_get_current_palette(dasher_ctx* ctx) {
@@ -645,7 +644,7 @@ DASHER_API int dasher_get_palette_preview_colors(dasher_ctx* ctx, int index, int
     if (!ctx || !ctx->intf || !out_colors) return -1;
     auto colorIO = ctx->intf->GetColorIO();
     if (!colorIO) return -1;
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_COLOUR_ID);
+    const auto& names = capi::permittedValues(ctx, Dasher::SP_COLOUR_ID);
     if (index < 0 || index >= static_cast<int>(names.size())) return -1;
     const auto* palette = colorIO->FindPalette(names[index]);
     if (!palette) return -1;
@@ -672,16 +671,14 @@ DASHER_API void dasher_set_palette(dasher_ctx* ctx, const char* palette_name) {
 
 DASHER_API int dasher_get_alphabet_count(dasher_ctx* ctx) {
     if (!ctx || !ctx->intf) return 0;
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_ALPHABET_ID);
-    return static_cast<int>(names.size());
+    return static_cast<int>(capi::permittedValues(ctx, Dasher::SP_ALPHABET_ID).size());
 }
 
 DASHER_API const char* dasher_get_alphabet_name(dasher_ctx* ctx, int index) {
     if (!ctx || !ctx->intf) return "";
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_ALPHABET_ID);
+    const auto& names = capi::permittedValues(ctx, Dasher::SP_ALPHABET_ID);
     if (index < 0 || index >= static_cast<int>(names.size())) return "";
-    ctx->scratch.stringValues = std::move(names);
-    return ctx->scratch.stringValues[index].c_str();
+    return names[index].c_str();
 }
 
 // ── Game Mode ───────────────────────────────────────────────────────────────

--- a/src/CAPI.cpp
+++ b/src/CAPI.cpp
@@ -54,19 +54,19 @@
 // behaviour overrides are defined here, out-of-line.
 
 struct dasher_ctx::Interface : public Dasher::CDashIntfScreenMsgs {
-        Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
-            s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
-                if (m_owner->callbacks.paramCb)
-                    m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
-                // Invalidate the permitted-value cache (todo.md 4.3). Deliberately
-                // AFTER the frontend callback: Event::Broadcast does not guarantee
-                // subscriber call order (see Event.h), so robustness here comes
-                // from laziness of refill — permittedValues() re-queries on the
-                // NEXT call, after every handler and re-entrant frontend access
-                // have settled — never from ordering assumptions.
-                ++m_owner->paramGeneration;
-            });
-        }
+    Interface(Dasher::CSettingsStore* s, dasher_ctx* owner) : CDashIntfScreenMsgs(s), m_owner(owner) {
+        s->OnParameterChanged.Subscribe(m_owner, [this](Dasher::Parameter param) {
+            if (m_owner->callbacks.paramCb)
+                m_owner->callbacks.paramCb(static_cast<int>(param), m_owner->callbacks.paramCbUserData);
+            // Invalidate the permitted-value cache (todo.md 4.3). Deliberately
+            // AFTER the frontend callback: Event::Broadcast does not guarantee
+            // subscriber call order (see Event.h), so robustness here comes
+            // from laziness of refill — permittedValues() re-queries on the
+            // NEXT call, after every handler and re-entrant frontend access
+            // have settled — never from ordering assumptions.
+            ++m_owner->paramGeneration;
+        });
+    }
     ~Interface() { m_pSettingsStore->OnParameterChanged.Unsubscribe(m_owner); }
     void CreateModules() override {
         CDashIntfScreenMsgs::CreateModules();

--- a/src/CAPI_appearance.cpp
+++ b/src/CAPI_appearance.cpp
@@ -147,11 +147,13 @@ DASHER_API int dasher_get_palette_appearance(dasher_ctx* ctx, int index) {
 }
 
 DASHER_API const char* dasher_find_companion_palette(dasher_ctx* ctx, const char* palette_name) {
-    if (!ctx || !ctx->intf || !palette_name) return nullptr;
+    // "" (not NULL) for "no companion" since CAPI version 2 — the standard
+    // string failure value; see the error-conventions section in dasher.h.
+    if (!ctx || !ctx->intf || !palette_name) return "";
     auto colorIO = ctx->intf->GetColorIO();
-    if (!colorIO) return nullptr;
+    if (!colorIO) return "";
     const Dasher::ColorPalette* comp = companionLookup(colorIO, palette_name);
-    if (!comp) return nullptr;
+    if (!comp) return "";
     ctx->scratch.tlString = comp->PaletteName;
     return ctx->scratch.tlString.c_str();
 }

--- a/src/CAPI_appearance.cpp
+++ b/src/CAPI_appearance.cpp
@@ -139,7 +139,7 @@ DASHER_API int dasher_get_palette_appearance(dasher_ctx* ctx, int index) {
     if (!ctx || !ctx->intf) return -1;
     auto colorIO = ctx->intf->GetColorIO();
     if (!colorIO) return -1;
-    auto names = ctx->intf->GetPermittedValues(Dasher::SP_COLOUR_ID);
+    const auto& names = capi::permittedValues(ctx, Dasher::SP_COLOUR_ID);
     if (index < 0 || index >= static_cast<int>(names.size())) return -1;
     const Dasher::ColorPalette* p = colorIO->FindPalette(names[index]);
     if (!p || p->PaletteName != names[index]) return 0; // not found -> unspecified

--- a/src/CAPI_edit.cpp
+++ b/src/CAPI_edit.cpp
@@ -148,6 +148,7 @@ static bool ensure_realized_for_context(dasher_ctx* ctx) {
     try {
         ctx->intf->Realize(nowMs());
         ctx->realized = true;
+        capi::invalidatePermittedCache(ctx); // lists repopulated silently
         return true;
     } catch (...) {
         return false;

--- a/src/CAPI_internal.h
+++ b/src/CAPI_internal.h
@@ -145,6 +145,7 @@ struct dasher_ctx {
     // "valid until the next API call" contract.
     struct PermittedCache {
         int key = -1;
+        bool valid = false; // invalidated state must not match ANY key, incl. -1
         uint64_t generation = 0;
         std::vector<std::string> values;
     } permitted;
@@ -385,14 +386,16 @@ namespace capi {
 // filter list — all parameter-change-silent), so generation bumps alone
 // cannot cover the pre->post-Realize transition (review loop 1, PR #2).
 DASHER_LOCAL inline void invalidatePermittedCache(dasher_ctx* ctx) {
-    ctx->permitted.key = -1;
+    ctx->permitted.valid = false;
 }
 
 DASHER_LOCAL inline const std::vector<std::string>& permittedValues(dasher_ctx* ctx, Dasher::Parameter key) {
-    if (ctx->permitted.key != static_cast<int>(key) || ctx->permitted.generation != ctx->paramGeneration) {
+    if (!ctx->permitted.valid || ctx->permitted.key != static_cast<int>(key) ||
+        ctx->permitted.generation != ctx->paramGeneration) {
         ctx->permitted.values = ctx->intf->GetPermittedValues(key);
         ctx->permitted.key = static_cast<int>(key);
         ctx->permitted.generation = ctx->paramGeneration;
+        ctx->permitted.valid = true;
     }
     return ctx->permitted.values;
 }

--- a/src/CAPI_internal.h
+++ b/src/CAPI_internal.h
@@ -18,6 +18,7 @@
 
 #include "DasherCore/ControlManager.h"
 #include "DasherCore/DashIntfScreenMsgs.h"
+#include "DasherCore/Parameters.h"
 #include "DasherCore/ColorPalette.h"
 #include "DasherCore/XmlSettingsStore.h"
 
@@ -133,6 +134,21 @@ struct dasher_ctx {
         std::vector<std::string> nodeLabelStrings; // Strand 2 (RFC 0013) node labels
         std::vector<char*> nodeLabelPtrs;
     } scratch;
+
+    // Permitted-value memoization (todo.md 4.3): the indexed palette/alphabet
+    // getters and the string-values getter each rebuilt the engine's
+    // permitted-value vector on every call — iterating 622 alphabets rebuilt
+    // it 622 times. One cached list; a different key or ANY parameter change
+    // (module/colour/alphabet registration fires OnParameterChanged, which
+    // bumps paramGeneration) invalidates it. Returned pointers point into
+    // the cached vector, which meets (and exceeds) the documented
+    // "valid until the next API call" contract.
+    struct PermittedCache {
+        int key = -1;
+        uint64_t generation = 0;
+        std::vector<std::string> values;
+    } permitted;
+    uint64_t paramGeneration = 0;
 
     // Appearance model state (RFC 0007). Lives at the C API layer — appearance
     // is a shell/canvas concern, not a DasherCore engine parameter. Persisted to
@@ -354,6 +370,23 @@ inline DASHER_LOCAL void notify_buffer_cleared(dasher_ctx* ctx) {
     if (ctx->callbacks.outputCb)
         ctx->callbacks.outputCb(DASHER_EVENT_BUFFER_CLEAR, "", ctx->callbacks.outputCbUserData);
 }
+
+// ── Permitted-value choke point ──────────────────────────────────────────────
+
+// Memoized GetPermittedValues for the ctx (see dasher_ctx::permitted):
+// invalidates on key change or ANY parameter change. Single definition
+// shared by CAPI.cpp's palette/alphabet getters and CAPI_params.cpp's
+// dasher_get_parameter_string_values (todo.md 4.3).
+namespace capi {
+DASHER_LOCAL inline const std::vector<std::string>& permittedValues(dasher_ctx* ctx, Dasher::Parameter key) {
+    if (ctx->permitted.key != static_cast<int>(key) || ctx->permitted.generation != ctx->paramGeneration) {
+        ctx->permitted.values = ctx->intf->GetPermittedValues(key);
+        ctx->permitted.key = static_cast<int>(key);
+        ctx->permitted.generation = ctx->paramGeneration;
+    }
+    return ctx->permitted.values;
+}
+} // namespace capi
 
 // ── Custom-action adapter ───────────────────────────────────────────────────
 

--- a/src/CAPI_internal.h
+++ b/src/CAPI_internal.h
@@ -380,8 +380,8 @@ inline DASHER_LOCAL void notify_buffer_cleared(dasher_ctx* ctx) {
 namespace capi {
 // Force a refill on the next permittedValues() call. Called at every
 // realize boundary: Realize() populates the alphabet/colour/filter lists
-// WITHOUT firing OnParameterChanged (CreateModules registers ~10 input
-// filters, the AlphIO/ColorIO scans, and low-memory mode shrinks the
+// WITHOUT firing OnParameterChanged (CreateModules registers a dozen-plus
+// input filters, the AlphIO/ColorIO scans, and low-memory mode shrinks the
 // filter list — all parameter-change-silent), so generation bumps alone
 // cannot cover the pre->post-Realize transition (review loop 1, PR #2).
 DASHER_LOCAL inline void invalidatePermittedCache(dasher_ctx* ctx) {

--- a/src/CAPI_internal.h
+++ b/src/CAPI_internal.h
@@ -378,6 +378,16 @@ inline DASHER_LOCAL void notify_buffer_cleared(dasher_ctx* ctx) {
 // shared by CAPI.cpp's palette/alphabet getters and CAPI_params.cpp's
 // dasher_get_parameter_string_values (todo.md 4.3).
 namespace capi {
+// Force a refill on the next permittedValues() call. Called at every
+// realize boundary: Realize() populates the alphabet/colour/filter lists
+// WITHOUT firing OnParameterChanged (CreateModules registers ~10 input
+// filters, the AlphIO/ColorIO scans, and low-memory mode shrinks the
+// filter list — all parameter-change-silent), so generation bumps alone
+// cannot cover the pre->post-Realize transition (review loop 1, PR #2).
+DASHER_LOCAL inline void invalidatePermittedCache(dasher_ctx* ctx) {
+    ctx->permitted.key = -1;
+}
+
 DASHER_LOCAL inline const std::vector<std::string>& permittedValues(dasher_ctx* ctx, Dasher::Parameter key) {
     if (ctx->permitted.key != static_cast<int>(key) || ctx->permitted.generation != ctx->paramGeneration) {
         ctx->permitted.values = ctx->intf->GetPermittedValues(key);

--- a/src/CAPI_params.cpp
+++ b/src/CAPI_params.cpp
@@ -55,7 +55,7 @@ DASHER_API int dasher_get_language_model_id_at(int index) {
 DASHER_API const char* dasher_get_language_model_name(int id) {
     static std::string s_buf;
     auto* desc = Dasher::LMRegistry::instance().get(id);
-    if (!desc) return "Unknown";
+    if (!desc) return "";
     s_buf = desc->name;
     return s_buf.c_str();
 }

--- a/src/CAPI_params.cpp
+++ b/src/CAPI_params.cpp
@@ -183,24 +183,24 @@ DASHER_API int dasher_get_parameter_enum_value(int key, int index) {
 }
 
 DASHER_API int dasher_get_parameter_string_values(dasher_ctx* ctx, int key, const char** out_names, int max_out) {
-    if (!ctx) return 0;
-    ctx->scratch.stringValues.clear();
+    if (!ctx || !ctx->intf) return 0;
 
-    if (ctx->intf) {
-        ctx->scratch.stringValues = ctx->intf->GetPermittedValues(static_cast<Dasher::Parameter>(key));
-    }
+    // Through the shared memoization cache (todo.md 4.3): returned pointers
+    // address the cached vector — valid at least until the next API call,
+    // like every string return in this API.
+    const auto& values = capi::permittedValues(ctx, static_cast<Dasher::Parameter>(key));
 
     // Probe call (null buffer / zero capacity): return the full count so
     // callers can size a buffer and call again. Previously this returned 0
     // before ever querying the engine, so every permitted-value list (e.g.
     // the 622 alphabets) came back empty and frontends rendered blank
     // pickers.
-    if (!out_names || max_out <= 0) return static_cast<int>(ctx->scratch.stringValues.size());
+    if (!out_names || max_out <= 0) return static_cast<int>(values.size());
 
-    int count = static_cast<int>(ctx->scratch.stringValues.size());
+    int count = static_cast<int>(values.size());
     if (count > max_out) count = max_out;
     for (int i = 0; i < count; i++) {
-        out_names[i] = ctx->scratch.stringValues[i].c_str();
+        out_names[i] = values[i].c_str();
     }
     return count;
 }

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -364,7 +364,7 @@ DASHER_API int dasher_get_palette_appearance(dasher_ctx* ctx, int index);
 
 // Find the companion (opposite-appearance) palette for the given name.
 // Bidirectional lookup. Returns the companion name (valid until the next API
-// call), or NULL if the palette has no companion.
+// call), or "" if the palette has no companion (CAPI version 2; was NULL).
 DASHER_API const char* dasher_find_companion_palette(dasher_ctx* ctx, const char* palette_name);
 
 // Appearance mode (persisted). SYSTEM follows dasher_set_system_appearance;

--- a/src/dasher.h
+++ b/src/dasher.h
@@ -44,11 +44,10 @@
 //
 //  String returns (copy before the next API call):
 //    ""              — the normal "no value / error" result (most getters).
-//    NULL            — two outliers only: dasher_find_companion_palette
-//                      (no companion) and dasher_get_localized_string
-//                      (no translation). Everything else returns "".
-//    "Unknown"       — dasher_get_language_model_name for an unknown id
-//                      (its description counterpart returns "").
+//    NULL            — dasher_get_localized_string only (no translation
+//                      found — a distinct state from an empty translation;
+//                      frontends use it to pick fallbacks). Everything else
+//                      returns "" (unified at CAPI version 2).
 //
 //  Failure of the engine itself:
 //    dasher_has_engine_error() returns 1 after a C++ exception escaped a
@@ -726,8 +725,12 @@ DASHER_API void dasher_test_inject_failure(dasher_ctx* ctx, int site);
 //       (DasherCore#84). A frontend that re-imports the training file after
 //       create as a stopgap MUST skip that re-import at version >= 1 or the
 //       text would be counted twice.
+//   2 — string sentinels unified: dasher_get_language_model_name returns ""
+//       (was "Unknown") for an unknown id, and dasher_find_companion_palette
+//       returns "" (was NULL) when no companion exists. Frontends that
+//       branched on those exact values must treat "" as the failure case.
 DASHER_API int dasher_capi_version(void);
-#define DASHER_CAPI_VERSION 1
+#define DASHER_CAPI_VERSION 2
 
 // Get the current Dasher offset (character position in the output).
 // Returns -1 if the engine is not realized.

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -540,6 +540,81 @@ TEST_CASE("contracts/permitted-value cache: realize boundaries invalidate") {
     CHECK(dasher_get_alphabet_count(retry) == post);
 }
 
+TEST_CASE("contracts/permitted-value cache: invalid key never returns a stale list") {
+    // Greptile PR #91: invalidatePermittedCache used key = -1 as its
+    // sentinel, which collides with dasher_find_parameter_key's -1 for a
+    // failed lookup — a query with an invalid key could receive the
+    // previous parameter's cached list. The cache now carries an explicit
+    // validity flag.
+    ScopedContext ctx(800, 600);
+    const int filter_key = dasher_find_parameter_key("SP_INPUT_FILTER");
+    REQUIRE(filter_key >= 0);
+
+    // Fill the cache with a real list, then query with keys that fail
+    // lookup: must return 0, never the stale cached list.
+    REQUIRE(dasher_get_parameter_string_values(ctx, filter_key, nullptr, 0) > 1);
+    CHECK(dasher_get_parameter_string_values(ctx, -1, nullptr, 0) == 0);
+    CHECK(dasher_get_parameter_string_values(ctx, 99999, nullptr, 0) == 0);
+
+    // Same after a realize-boundary invalidation on a second context.
+    ScopedContext fresh;
+    dasher_set_screen_size(fresh, 800, 600);
+    REQUIRE(dasher_get_parameter_string_values(fresh, filter_key, nullptr, 0) > 1);
+    ScopedContext fresh2;
+    dasher_set_screen_size(fresh2, 800, 600);
+    CHECK(dasher_get_parameter_string_values(fresh2, -1, nullptr, 0) == 0);
+}
+
+namespace {
+// Re-entrant probe for the param-callback test: doctest is single-threaded,
+// a file-scope ctx pointer is the simplest way for the callback to reach it.
+dasher_ctx* g_probeCtx = nullptr;
+int g_probeKey = -1;
+int g_probeCount = -1;
+bool g_probeFired = false;
+void probe_param_cb(int, void*) {
+    if (g_probeFired) return;
+    g_probeFired = true;
+    g_probeCount = dasher_get_parameter_string_values(g_probeCtx, g_probeKey, nullptr, 0);
+}
+} // namespace
+
+TEST_CASE("contracts/permitted-value cache: re-entrant query inside param callback sees fresh data") {
+    // Greptile PR #91: the generation bump used to run after the frontend
+    // callback, so a settings UI re-querying a permitted list from inside
+    // the parameter-change notification read the stale cached value. The
+    // cache is invalidated BEFORE the callback fires; the generation bump
+    // AFTER it flags any mid-callback refill stale for the next query.
+    ScopedContext ctx(800, 600);
+    const int filter_key = dasher_find_parameter_key("SP_INPUT_FILTER");
+    REQUIRE(filter_key >= 0);
+    const int primed = dasher_get_parameter_string_values(ctx, filter_key, nullptr, 0);
+    REQUIRE(primed > 1); // cache primed with the filter list
+
+    g_probeCtx = ctx.ctx;
+    g_probeKey = filter_key;
+    g_probeCount = -1;
+    g_probeFired = false;
+    dasher_set_parameter_callback(ctx, probe_param_cb, nullptr);
+
+    // Any parameter change fires the notification; the re-entrant query
+    // inside it must see a full fresh list (the invalid key -1 scenario
+    // aside, a stale cache would still have returned the same filter list,
+    // so the real assertion is: fresh refill works and nothing crashes or
+    // corrupts — count during callback equals the primed count).
+    dasher_set_speed_percent(ctx, 250);
+    REQUIRE(g_probeFired);
+    CHECK(g_probeCount == primed);
+
+    // And after the broadcast settles, the post-callback generation bump
+    // made even the mid-callback refill stale — the next query still
+    // returns the correct full list.
+    CHECK(dasher_get_parameter_string_values(ctx, filter_key, nullptr, 0) == primed);
+
+    dasher_set_parameter_callback(ctx, nullptr, nullptr);
+    g_probeCtx = nullptr;
+}
+
 TEST_CASE("contracts/permitted-value cache: low-memory filter list is honored") {
     // Low-memory mode silently shrinks the registered input filters during
     // CreateModules — a parameter-change-silent list mutation the

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -447,3 +447,67 @@ TEST_CASE("contracts/engine-error lifecycle: failed Realize latches, retry recov
     dasher_frame(ctx, 1000, &cmds, &cc, &strs, &sc);
     CHECK(cc >= 6);
 }
+
+// ---------------------------------------------------------------------------
+// Permitted-value cache (todo.md 4.3). The indexed list getters and
+// dasher_get_parameter_string_values share one memoized list per ctx,
+// invalidated by ANY parameter change. Pins: stable iteration, cache
+// coherence across the getter family, and invalidation after a real
+// parameter change (palette switch fires OnParameterChanged).
+// ---------------------------------------------------------------------------
+
+TEST_CASE("contracts/permitted-value cache: iteration stable, family coherent, invalidates on change") {
+    ScopedContext ctx(800, 600);
+
+    const int count = dasher_get_alphabet_count(ctx);
+    REQUIRE(count > 1);
+
+    // Full iteration, twice: the second pass must see identical values
+    // (cache refill must not corrupt or reorder), and the names must match
+    // a get_parameter_string_values snapshot taken through the same cache.
+    std::vector<std::string> first_pass;
+    for (int i = 0; i < count; i++)
+        first_pass.emplace_back(dasher_get_alphabet_name(ctx, i));
+    for (int i = 0; i < count; i++)
+        CHECK(std::string(dasher_get_alphabet_name(ctx, i)) == first_pass[i]);
+
+    std::vector<const char*> snapshot(count);
+    REQUIRE(dasher_get_parameter_string_values(ctx, dasher_find_parameter_key("SP_ALPHABET_ID"), snapshot.data(),
+                                               count) == count);
+    for (int i = 0; i < count; i++)
+        CHECK(std::string(snapshot[i]) == first_pass[i]);
+
+    // The active alphabet appears in the list.
+    const std::string active = dasher_get_alphabet_id(ctx);
+    bool found = false;
+    for (auto& n : first_pass)
+        found |= (n == active);
+    CHECK(found);
+
+    // A parameter change (palette switch fires OnParameterChanged) must
+    // invalidate, not corrupt: the alphabet list is still complete and
+    // correct afterwards, and the palette list reflects the new palette.
+    const std::string old_palette = dasher_get_current_palette(ctx);
+    std::string target;
+    const int pcount = dasher_get_palette_count(ctx);
+    for (int i = 0; i < pcount; i++) {
+        std::string n = dasher_get_palette_name(ctx, i);
+        if (n != old_palette) {
+            target = n;
+            break;
+        }
+    }
+    REQUIRE(!target.empty());
+    dasher_set_palette(ctx, target.c_str());
+    CHECK(std::string(dasher_get_current_palette(ctx)) == target);
+
+    // Post-change: alphabet list unchanged in content...
+    CHECK(dasher_get_alphabet_count(ctx) == count);
+    for (int i = 0; i < count; i++)
+        CHECK(std::string(dasher_get_alphabet_name(ctx, i)) == first_pass[i]);
+    // ...and the palette list still contains the newly active palette.
+    bool has_new = false;
+    for (int i = 0; i < dasher_get_palette_count(ctx); i++)
+        has_new |= (std::string(dasher_get_palette_name(ctx, i)) == target);
+    CHECK(has_new);
+}

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -98,7 +98,7 @@ TEST_CASE("contracts/null ctx tolerated across the API surface") {
     CHECK(std::string(dasher_get_palette_name(nullptr, 0)) == "");
     CHECK(std::string(dasher_get_current_palette(nullptr)) == "");
     CHECK(dasher_get_palette_appearance(nullptr, 0) == -1);
-    CHECK(dasher_find_companion_palette(nullptr, "Default") == nullptr);
+    CHECK(std::string(dasher_find_companion_palette(nullptr, "Default")) == "");
     CHECK(std::string(dasher_get_light_palette(nullptr)) == "");
     CHECK(std::string(dasher_get_dark_palette(nullptr)) == "");
     CHECK(dasher_get_alphabet_count(nullptr) == 0);
@@ -196,9 +196,10 @@ TEST_CASE("contracts/integer error sentinels") {
 }
 
 // ---------------------------------------------------------------------------
-// String sentinels. "" is the common failure value; two functions return
-// NULL instead (dasher_find_companion_palette, dasher_get_localized_string)
-// (unified to "" at CAPI version 2 — todo.md Phase 4).
+// String sentinels. "" is the universal failure value since CAPI version 2
+// (todo.md Phase 4 unified the outliers). The single remaining NULL return
+// is dasher_get_localized_string: "missing translation" is a distinct state
+// from an empty translation, and frontends use it to pick fallbacks.
 // ---------------------------------------------------------------------------
 
 TEST_CASE("contracts/string error sentinels") {
@@ -225,7 +226,7 @@ TEST_CASE("contracts/string error sentinels") {
     CHECK(std::string(dasher_get_alphabet_name(ctx, 1 << 20)) == "");
 
     // NULL sentinels (the outliers — see file header).
-    CHECK(dasher_find_companion_palette(ctx, "No Such Palette Exists") == nullptr);
+    CHECK(std::string(dasher_find_companion_palette(ctx, "No Such Palette Exists")) == "");
     CHECK(dasher_get_localized_string(ctx, "no.such.key") == nullptr);
     CHECK(dasher_get_localized_string(ctx, nullptr) == nullptr);
 

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -536,14 +536,19 @@ TEST_CASE("contracts/permitted-value cache: realize boundaries invalidate") {
     dasher_test_inject_failure(retry, DASHER_FAIL_INJECT_NONE);
     dasher_set_screen_size(retry, 800, 600); // retry: interface recreated + realized
     CHECK(dasher_has_engine_error(retry) == 0);
+    // Same data dir -> same alphabet count (exact equality is deliberate).
     CHECK(dasher_get_alphabet_count(retry) == post);
 }
 
 TEST_CASE("contracts/permitted-value cache: low-memory filter list is honored") {
     // Low-memory mode silently shrinks the registered input filters during
-    // CreateModules — another parameter-change-silent list mutation covered
-    // only by the realize-boundary invalidation. Inequalities, not exact
-    // counts, so module additions don't break the pin.
+    // CreateModules — a parameter-change-silent list mutation the
+    // realize-boundary invalidation must cover (with a persisted settings
+    // file, realize fires no parameter change, so the boundary call is the
+    // ONLY guard). The pre-realize query fills the cache; without
+    // invalidation the post-realize query would return the stale cached
+    // 0 and the low_count >= 1 check below would fail. Inequalities, not
+    // exact counts, so module additions don't break the pin.
     ScopedContext normal(800, 600);
     const int filter_key = dasher_find_parameter_key("SP_INPUT_FILTER");
     REQUIRE(filter_key >= 0);
@@ -552,7 +557,10 @@ TEST_CASE("contracts/permitted-value cache: low-memory filter list is honored") 
 
     ScopedContext lowmem; // low-memory BEFORE the realize
     dasher_set_low_memory_mode(lowmem, 1);
-    dasher_set_screen_size(lowmem, 800, 600);
+    // Fill the cache with the pre-realize answer first.
+    (void)dasher_get_parameter_string_values(lowmem, filter_key, nullptr, 0);
+    dasher_set_screen_size(lowmem, 800, 600); // realize: list shrinks silently
     const int low_count = dasher_get_parameter_string_values(lowmem, filter_key, nullptr, 0);
+    CHECK(low_count >= 1); // > 0 proves the cache was invalidated, not stale
     CHECK(low_count < normal_count);
 }

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -198,8 +198,7 @@ TEST_CASE("contracts/integer error sentinels") {
 // ---------------------------------------------------------------------------
 // String sentinels. "" is the common failure value; two functions return
 // NULL instead (dasher_find_companion_palette, dasher_get_localized_string)
-// and dasher_get_language_model_name returns "Unknown" — the outliers this
-// file exists to keep visible until todo.md Phase 4 unifies them.
+// (unified to "" at CAPI version 2 — todo.md Phase 4).
 // ---------------------------------------------------------------------------
 
 TEST_CASE("contracts/string error sentinels") {
@@ -215,8 +214,8 @@ TEST_CASE("contracts/string error sentinels") {
     REQUIRE(std::string(name1).size() > 0);
     (void)dasher_get_language_model_description(valid_lm);
     CHECK(std::string(name1) == std::string(dasher_get_language_model_name(valid_lm))); // not clobbered
-    // Invalid id sentinels: "Unknown" literal vs "" (the outlier, Phase 4).
-    CHECK(std::string(dasher_get_language_model_name(-999)) == "Unknown");
+    // Invalid id sentinels: "" since CAPI version 2 (was "Unknown").
+    CHECK(std::string(dasher_get_language_model_name(-999)) == "");
     CHECK(std::string(dasher_get_language_model_description(-999)) == "");
     CHECK(std::string(dasher_get_parameter_enum_name(-999, 0)) == "");
 

--- a/tests/test_capi_contracts.cpp
+++ b/tests/test_capi_contracts.cpp
@@ -511,3 +511,48 @@ TEST_CASE("contracts/permitted-value cache: iteration stable, family coherent, i
         has_new |= (std::string(dasher_get_palette_name(ctx, i)) == target);
     CHECK(has_new);
 }
+
+TEST_CASE("contracts/permitted-value cache: realize boundaries invalidate") {
+    // Realize() populates the alphabet/colour/filter lists WITHOUT firing
+    // OnParameterChanged, so a frontend that builds its pickers before
+    // dasher_set_screen_size would cache the empty pre-realize answers
+    // forever if the realize boundary didn't invalidate. (Found by review
+    // loop 1; this test is the regression guard.)
+    ScopedContext unrealized; // created, never given a screen size
+    REQUIRE(unrealized.ctx != nullptr);
+    const int pre = dasher_get_alphabet_count(unrealized); // caches the answer
+    dasher_set_screen_size(unrealized, 800, 600);          // realize
+    const int post = dasher_get_alphabet_count(unrealized);
+    CHECK(post > pre);
+    REQUIRE(post > 1); // Data/ ships hundreds; a stale 0 or 1 fails here
+
+    // Same boundary on the failed-Realize retry path: the cache lives on
+    // the ctx and must not survive the interface recreation either.
+    ScopedContext retry;
+    dasher_test_inject_failure(retry, DASHER_FAIL_INJECT_REALIZE);
+    dasher_set_screen_size(retry, 800, 600); // realize fails, engineError latches
+    CHECK(dasher_has_engine_error(retry) == 1);
+    (void)dasher_get_alphabet_count(retry); // caches whatever the broken state reports
+    dasher_test_inject_failure(retry, DASHER_FAIL_INJECT_NONE);
+    dasher_set_screen_size(retry, 800, 600); // retry: interface recreated + realized
+    CHECK(dasher_has_engine_error(retry) == 0);
+    CHECK(dasher_get_alphabet_count(retry) == post);
+}
+
+TEST_CASE("contracts/permitted-value cache: low-memory filter list is honored") {
+    // Low-memory mode silently shrinks the registered input filters during
+    // CreateModules — another parameter-change-silent list mutation covered
+    // only by the realize-boundary invalidation. Inequalities, not exact
+    // counts, so module additions don't break the pin.
+    ScopedContext normal(800, 600);
+    const int filter_key = dasher_find_parameter_key("SP_INPUT_FILTER");
+    REQUIRE(filter_key >= 0);
+    const int normal_count = dasher_get_parameter_string_values(normal, filter_key, nullptr, 0);
+    REQUIRE(normal_count > 1);
+
+    ScopedContext lowmem; // low-memory BEFORE the realize
+    dasher_set_low_memory_mode(lowmem, 1);
+    dasher_set_screen_size(lowmem, 800, 600);
+    const int low_count = dasher_get_parameter_string_values(lowmem, filter_key, nullptr, 0);
+    CHECK(low_count < normal_count);
+}

--- a/tests/test_color_math.cpp
+++ b/tests/test_color_math.cpp
@@ -146,9 +146,10 @@ TEST(color_palette_companion_lookup) {
     ASSERT(comp_of_dark);
     ASSERT_STR_EQ(comp_of_dark, "Rainbow");
 
-    // A palette with no companion (Yellow on Blue is inherently dark) returns NULL.
+    // A palette with no companion (Yellow on Blue is inherently dark) returns ""
+    // (CAPI version 2; was NULL).
     const char* none = dasher_find_companion_palette(ctx, "Yellow on Blue");
-    ASSERT(none == nullptr);
+    ASSERT_STR_EQ(none, "");
 
     dasher_destroy(ctx);
 }

--- a/tests/test_language_models.cpp
+++ b/tests/test_language_models.cpp
@@ -30,7 +30,7 @@ TEST(lm_list_and_ids) {
 }
 
 TEST(lm_unknown_returns_safe_defaults) {
-    ASSERT_STR_EQ(dasher_get_language_model_name(99999), "Unknown");
+    ASSERT_STR_EQ(dasher_get_language_model_name(99999), "");
     ASSERT_STR_EQ(dasher_get_language_model_description(99999), "");
     ASSERT_EQ(dasher_get_language_model_param_count(99999), 0);
     ASSERT_EQ(dasher_get_language_model_param_key(99999, 0), -1);

--- a/todo.md
+++ b/todo.md
@@ -221,20 +221,20 @@ Target layout (internal only; `dasher.h` unchanged, still one public header):
         body); dasher_capi_tests hung, caught by the build-to-100%-then-
         test rule before commit
 
-## Phase 4 — consistency fixes (small, test-visible — decide each one)
+## Phase 4 — consistency fixes (small, test-visible)
 
-Each of these changes observable behaviour slightly. Do them one PR each,
-with tests, NOT bundled with the refactor.
+Shipped as PR #2 (branch capi/phase-4-consistency), one commit per change:
 
-- [ ] 4.1 `dasher_get_language_model_name` returns "Unknown" on bad id but
-      `..._description` returns "" — pick one ("" recommended) + test.
-- [ ] 4.2 Decide NULL-vs-"" policy for string getters; fix outliers
-      (`dasher_find_companion_palette` returns NULL, most others "").
-      Needs a `DASHER_CAPI_VERSION` bump if frontends might branch on it.
-- [ ] 4.3 Cache `GetPermittedValues` result on ctx so the indexed palette/
-      alphabet name getters stop rebuilding the vector per call (622-alphabet
-      loop currently rebuilds 622×). Perf-only, but add a timing/behaviour
-      test that iteration returns stable, correct names.
+- [x] 4.1 LM-name sentinel: "Unknown" → "" (matches its description twin).
+- [x] 4.2 NULL-vs-"": dasher_find_companion_palette NULL → "". NULL survives
+      in exactly one documented place — dasher_get_localized_string, where
+      "missing translation" is a distinct state frontends branch on.
+      DASHER_CAPI_VERSION 1 → 2 with the full behavioural note (both 4.1
+      and 4.2) in dasher.h.
+- [x] 4.3 Permitted-value memoization on the ctx (capi::permittedValues),
+      invalidated by key change or ANY parameter change; all five list
+      getters routed through it. Cache test: stable double iteration,
+      snapshot coherence, post-switch invalidation.
 
 ## Phase 5 — bigger cleanups (only after 1–4 land)
 

--- a/todo.md
+++ b/todo.md
@@ -236,12 +236,18 @@ Shipped as PR #2 (branch capi/phase-4-consistency), one commit per change:
       boundary (Realize populates the lists without firing
       OnParameterChanged — low-memory mode and the AlphIO/ColorIO scans
       are parameter-silent). Seven functions across five list families
-      routed through it. HONESTY NOTE: the first cut (fd943e6b) shipped
-      the cache with an invalidation mechanism that existed only in its
-      commit message (a text-replace silently no-op'd against
-      clang-formatted code) and a vacuous test; review loop 1 scored the
-      branch 5/10 and proved the bug. Fixed in the follow-up commit with
-      real boundary tests (pre-realize growth, retry path, low-memory).
+      routed through it. HONESTY NOTE (kept deliberately): TWO review
+      rounds caught the same failure mode — a claim without the code.
+      Round 1: the first cut (fd943e6b) shipped the cache with an
+      invalidation mechanism that existed only in its commit message (a
+      python replace() silently no-op'd against clang-formatted code) plus
+      a vacuous test. Round 2: the remediation commit (8520bccf) claimed
+      the three boundary tests were added — the test-file replace had
+      no-op'd the same way. Finally landed with match-verified edits and a
+      MUTATION TEST: removing both invalidation mechanisms makes the suite
+      fail on exactly the loop-1 bug (pre-realize 0 cached forever);
+      either mechanism alone keeps it green. Process rule: scripted
+      replaces must assert the pattern matched.
 
 ## Phase 5 — bigger cleanups (only after 1–4 land)
 

--- a/todo.md
+++ b/todo.md
@@ -232,9 +232,16 @@ Shipped as PR #2 (branch capi/phase-4-consistency), one commit per change:
       DASHER_CAPI_VERSION 1 → 2 with the full behavioural note (both 4.1
       and 4.2) in dasher.h.
 - [x] 4.3 Permitted-value memoization on the ctx (capi::permittedValues),
-      invalidated by key change or ANY parameter change; all five list
-      getters routed through it. Cache test: stable double iteration,
-      snapshot coherence, post-switch invalidation.
+      invalidated by key change, ANY parameter change, AND every realize
+      boundary (Realize populates the lists without firing
+      OnParameterChanged — low-memory mode and the AlphIO/ColorIO scans
+      are parameter-silent). Seven functions across five list families
+      routed through it. HONESTY NOTE: the first cut (fd943e6b) shipped
+      the cache with an invalidation mechanism that existed only in its
+      commit message (a text-replace silently no-op'd against
+      clang-formatted code) and a vacuous test; review loop 1 scored the
+      branch 5/10 and proved the bug. Fixed in the follow-up commit with
+      real boundary tests (pre-realize growth, retry path, low-memory).
 
 ## Phase 5 — bigger cleanups (only after 1–4 land)
 

--- a/todo.md
+++ b/todo.md
@@ -245,9 +245,13 @@ Shipped as PR #2 (branch capi/phase-4-consistency), one commit per change:
       the three boundary tests were added — the test-file replace had
       no-op'd the same way. Finally landed with match-verified edits and a
       MUTATION TEST: removing both invalidation mechanisms makes the suite
-      fail on exactly the loop-1 bug (pre-realize 0 cached forever);
-      either mechanism alone keeps it green. Process rule: scripted
-      replaces must assert the pattern matched.
+      fail on exactly the loop-1 bug (pre-realize 0 cached forever).
+      Either mechanism alone keeps the SUITE green — but that rides on
+      fresh-install realize firing a parameter broadcast; with a persisted
+      settings file the realize-boundary call is the only guard, so both
+      stay. Process rules: scripted replaces must assert the pattern
+      matched; mutation checks must confirm the mutated build actually
+      relinked (a stale binary gives a false green).
 
 ## Phase 5 — bigger cleanups (only after 1–4 land)
 


### PR DESCRIPTION
## What

Phase 4 of the CAPI cleanup tracked in `todo.md`, stacked conceptually on #90 (Phases 0-3, merged). Two small behaviour changes (version-gated) and one perf fix. No ABI surface change (110 exported symbols, frozen).

## 4.1 + 4.2 — string sentinels unified, DASHER_CAPI_VERSION 1 → 2

- `dasher_get_language_model_name` returns `""` (was `"Unknown"`) for an unknown id — it was the last getter disagreeing with its own description twin.
- `dasher_find_companion_palette` returns `""` (was `NULL`) for no-companion.
- NULL for string failures now survives in exactly ONE documented place: `dasher_get_localized_string`, where "missing translation" is a genuinely distinct state frontends branch on for fallbacks. That is now the documented exception, not an inconsistency.
- The v2 note in `dasher.h` describes both changes; frontends that matched `"Unknown"` or `NULL` literally must switch to `""`.

## 4.3 — permitted-value memoization

The indexed palette/alphabet getters, preview colours, appearance classification and `dasher_get_parameter_string_values` each rebuilt the engine's permitted-value vector per call — a picker iterating 622 alphabets rebuilt it 622 times. One cached list per ctx (`capi::permittedValues`), invalidated by:
1. a different key,
2. ANY parameter change (`++paramGeneration` in the OnParameterChanged subscription, deliberately AFTER the frontend callback — `Event::Broadcast` disclaims call order, robustness comes from lazy refill), and
3. **every realize boundary** — Realize() populates the alphabet/colour/filter lists WITHOUT firing parameter changes (CreateModules' 14 filter registrations, AlphIO/ColorIO scans, low-memory shrink are all parameter-silent), so generation bumps alone could never cover pre→post-Realize. With a persisted settings file, the boundary call is the only guard.

## Verification

- Build [100%] zero errors, **45/45 ctest**, exported symbols frozen at 110 — per commit.
- **Mutation-tested**: removing BOTH invalidation mechanisms fails the suite on exactly the original bug (pre-realize `0` cached forever); either mechanism alone keeps the suite green (scoped honestly: that rides on fresh-install realize firing a parameter broadcast).
- Own review loop: 5/10 → 5/10 → 8/10. The first two loops caught the same failure mode twice — a scripted text-replace silently no-op'd against clang-formatted code, so two commits claimed an invalidation mechanism and then its tests before either was in the tree. Both corrected in-tree with match-asserted edits; the history and `todo.md` document it honestly, and the process rules (assert replaces matched; confirm mutated binaries relinked) are recorded.

## Reviewer notes

- Watch the commit messages' evolving claims on `fd943e6b`/`8520bccf` vs their diffs — deliberate paper trail, corrected by `17a1b9d3`/`2c244c4a`.
- No frontend action needed unless one matched `"Unknown"` or NULL literally.





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63385031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with both earlier cache findings addressed and no new actionable defect identified.

<h3>Summary</h3>

- Changes unknown language-model names and missing companion palettes to return `""`.
- Adds a shared permitted-value cache for alphabet, palette, preview, appearance, and parameter-introspection calls.
- Invalidates cached values across parameter notifications and realization boundaries.
- Adds regression coverage for invalid keys, re-entrant callbacks, realization retries, and low-memory initialization.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    H[Host getter] --> C{Cache valid for key<br/>and generation?}
    C -->|Yes| V[Return cached values]
    C -->|No| E[Read live permitted values]
    E --> V
    P[Parameter change] --> I[Invalidate before host callback]
    I --> B[Run synchronous callback]
    B --> G[Increment generation]
    R[Successful realization] --> I2[Invalidate cache]
    I2 --> C
    G --> C
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix(capi): greptile PR #91 P1s — re-entr..."](https://github.com/dasher-project/dashercore/commit/a9229911f12c40682a20825efd2237e8d6811ccd)</sub>

<!-- /greptile_comment -->