### PR TITLE
chore(release): bump VERSION to 0.2.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project("DasherCore" VERSION 0.2.23)
+project("DasherCore" VERSION 0.2.24)
 
 ###############################
 # Release-version drift guard


### PR DESCRIPTION
One-line release bump for the v0.2.24 tag (required by the #89 drift guard — tag must match `project()` VERSION exactly). Ships the CAPI cleanup stack: #90 (Phases 0-3), #91 (Phase 4, CAPI v2), #92 (Phase 5, CAPI v3).

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63415505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the new project version is consistent with the intended v0.2.24 release and existing version-consumption paths.

<h3>Summary</h3>

- The existing drift guard will accept `v0.2.24` and reject mismatched release tags.
- Windows version-resource metadata is generated from `PROJECT_VERSION` and therefore updates automatically.
- No additional authoritative version declarations require modification.

<sub>Reviews (1) · Last reviewed commit: ["chore(release): bump VERSION to 0.2.24"](https://github.com/dasher-project/dashercore/commit/9ca846a82fabd874962df94726b3d745c39e691e)</sub>

<!-- /greptile_comment -->